### PR TITLE
feat(nodes): implement parse_resume node with LLM-based extraction

### DIFF
--- a/docs/issues/004-resume-structured-extraction.md
+++ b/docs/issues/004-resume-structured-extraction.md
@@ -1,6 +1,7 @@
 # [Feature]: Implement parse_resume node (first LangGraph node)
 
 **Labels:** `enhancement`, `priority:high`
+**Status:** Done
 **Depends on:** [002](002-pdf-text-extraction.md), [003](003-llm-provider-setup.md)
 
 ## Description
@@ -13,28 +14,44 @@ Implement the `parse_resume` node — the first LangGraph node in the pipeline. 
 - First opportunity to learn the LangGraph node pattern: `(state) -> dict`
 - Validates that state flows correctly through the graph
 
-## Proposed Solution
+## Implementation
 
 1. Call `extract_text(state.resume_path)` for raw text
 2. Format the `PARSE_RESUME` prompt with the raw text
 3. Call `call_llm(prompt)` and parse the JSON response
-4. Return `{"resume": ResumeData(...)}` for LangGraph to merge into state
+4. Strip markdown code fences (```json ... ```) if present via `_strip_markdown_json()`
+5. Return `{"resume": ResumeData(...)}` for LangGraph to merge into state
+6. On parse failure, return fallback `ResumeData(raw_text=...)` with error appended
 
 ### Key pattern (LangGraph node)
 
 ```python
-def parse_resume(state: ApplicationState) -> dict:
+def parse_resume(state: ApplicationState) -> dict[str, Any]:
     raw_text = extract_text(state.resume_path)
     prompt = PARSE_RESUME.format(resume_text=raw_text)
-    response = call_llm(prompt)
     try:
-        data = json.loads(response)
+        response = call_llm(prompt)
+        cleaned = _strip_markdown_json(response)
+        data = json.loads(cleaned)
         resume = ResumeData(raw_text=raw_text, **data)
-    except (json.JSONDecodeError, ValueError) as e:
+    except (json.JSONDecodeError, ValidationError) as e:
         resume = ResumeData(raw_text=raw_text)
         return {"resume": resume, "errors": [*state.errors, f"Resume parse failed: {e}"]}
     return {"resume": resume}
 ```
+
+### Additional changes
+
+- **`ResumeData` null coercion** — Added a `model_validator` on `ResumeData` that coerces
+  `None` values to defaults (empty string, empty list). LLMs return `null` for missing
+  fields like phone number; without coercion Pydantic rejects them.
+- **`llm_max_tokens` config** — Added configurable `LLM_MAX_TOKENS` env var (default 8192)
+  passed to all LLM providers. Ensures long resumes with many experiences don't get
+  truncated by low default token limits.
+- **LLM call logging** — `call_llm()` logs provider, model, and execution time at INFO
+  level for model performance comparison.
+- **CLI Rich table** — `parse-resume` command displays structured data as a Rich table
+  with experience details and sentence counts.
 
 ### LangGraph concept: state updates
 
@@ -47,19 +64,22 @@ When a node returns `{"resume": resume}`, LangGraph only updates that field — 
 
 ## Acceptance Criteria
 
-- [ ] `parse_resume` node correctly extracts name, email, skills from a real resume PDF
-- [ ] Invalid LLM responses (bad JSON) don't crash — fall back to `ResumeData(raw_text=...)`
-- [ ] Markdown-wrapped JSON responses (```json ... ```) are handled
-- [ ] `parse-resume` CLI command shows structured data as a Rich table
-- [ ] Tests pass with mocked `extract_text` and `call_llm`
-- [ ] `ruff check` and `mypy` pass
+- [x] `parse_resume` node correctly extracts name, email, skills from a real resume PDF
+- [x] Invalid LLM responses (bad JSON) don't crash — fall back to `ResumeData(raw_text=...)`
+- [x] Markdown-wrapped JSON responses (```json ... ```) are handled
+- [x] `parse-resume` CLI command shows structured data as a Rich table
+- [x] Tests pass with mocked `extract_text` and `call_llm`
+- [x] `ruff check` and `mypy` pass
 
 ## Files Touched
 
-- `src/apply_operator/nodes/parse_resume.py` — implement
-- `src/apply_operator/prompts/resume_analysis.py` — refine prompt if needed
-- `src/apply_operator/main.py` — update `parse-resume` command output
-- `tests/test_parse_resume.py` — create
+- `src/apply_operator/nodes/parse_resume.py` — implemented node with `_strip_markdown_json` helper
+- `src/apply_operator/prompts/resume_analysis.py` — refined prompt, escaped braces, added null instruction
+- `src/apply_operator/main.py` — Rich table output with experience details, logging setup
+- `src/apply_operator/state.py` — `ResumeData` null coercion `model_validator`
+- `src/apply_operator/config.py` — added `llm_max_tokens` setting
+- `src/apply_operator/tools/llm_provider.py` — `max_tokens` support, execution time logging
+- `tests/test_parse_resume.py` — 11 tests (strip markdown, valid/invalid JSON, null fields, validation errors)
 
 ## Related Issues
 

--- a/src/apply_operator/config.py
+++ b/src/apply_operator/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     # LLM
     llm_provider: Literal["openai", "anthropic", "google", "openrouter"] = "openai"
     llm_model: str = "gpt-4o"
+    llm_max_tokens: int = 8192
     openai_api_key: str = ""
     anthropic_api_key: str = ""
     google_api_key: str = ""

--- a/src/apply_operator/main.py
+++ b/src/apply_operator/main.py
@@ -1,11 +1,21 @@
 """CLI entry point for the job application agent."""
 
+import logging
 from pathlib import Path
 from typing import Any
 
 import typer
 from rich.console import Console
+from rich.logging import RichHandler
 from rich.table import Table
+
+from apply_operator.config import get_settings
+
+logging.basicConfig(
+    level=get_settings().log_level,
+    format="%(name)s | %(message)s",
+    handlers=[RichHandler(rich_tracebacks=True, show_path=False)],
+)
 
 app = typer.Typer(
     name="apply-operator",
@@ -62,15 +72,49 @@ def parse_resume(
         console.print(f"[red]Resume file not found: {resume}[/red]")
         raise typer.Exit(code=1)
 
-    from apply_operator.tools.pdf_parser import extract_text
+    from apply_operator.nodes.parse_resume import parse_resume as _parse_resume
+    from apply_operator.state import ApplicationState
 
-    text = extract_text(str(resume))
-    if not text.strip():
-        console.print("[yellow]No text content found in the PDF.[/yellow]")
-        return
+    state = ApplicationState(resume_path=str(resume))
+    result = _parse_resume(state)
+    resume_data = result.get("resume")
 
-    console.print(f"[bold cyan]Extracted text[/bold cyan] ({len(text)} chars):\n")
-    console.print(text)
+    if result.get("errors"):
+        for err in result["errors"]:
+            console.print(f"[yellow]{err}[/yellow]")
+
+    if resume_data is None:
+        console.print("[red]Failed to parse resume.[/red]")
+        raise typer.Exit(code=1)
+
+    table = Table(title="Resume Data")
+    table.add_column("Field", style="cyan")
+    table.add_column("Value", style="white")
+
+    table.add_row("Name", resume_data.name or "[dim]—[/dim]")
+    table.add_row("Email", resume_data.email or "[dim]—[/dim]")
+    table.add_row("Phone", resume_data.phone or "[dim]—[/dim]")
+    table.add_row("Skills", ", ".join(resume_data.skills) if resume_data.skills else "[dim]—[/dim]")
+    table.add_row("Summary", resume_data.summary or "[dim]—[/dim]")
+
+    for i, exp in enumerate(resume_data.experience, 1):
+        title = exp.get("title", "")
+        company = exp.get("company", "")
+        duration = exp.get("duration", "")
+        description = exp.get("description") or ""
+        # Count sentences (split on . ! ?)
+        sentences = [s for s in description.replace("•", ".").split(".") if s.strip()]
+        header = f"[bold]{title}[/bold] @ {company} ({duration})"
+        detail = f"{description}\n[dim]({len(sentences)} details)[/dim]" if description else ""
+        table.add_row(f"Experience {i}", f"{header}\n{detail}" if detail else header)
+
+    for edu in resume_data.education:
+        degree = edu.get("degree", "")
+        institution = edu.get("institution", "")
+        year = edu.get("year", "")
+        table.add_row("Education", f"{degree}, {institution} ({year})")
+
+    console.print(table)
 
 
 def _print_results(state: dict[str, Any]) -> None:

--- a/src/apply_operator/nodes/parse_resume.py
+++ b/src/apply_operator/nodes/parse_resume.py
@@ -1,8 +1,23 @@
 """Node: Parse resume PDF and extract structured data."""
 
+import json
+import re
 from typing import Any
 
-from apply_operator.state import ApplicationState
+from pydantic import ValidationError
+
+from apply_operator.prompts.resume_analysis import PARSE_RESUME
+from apply_operator.state import ApplicationState, ResumeData
+from apply_operator.tools.llm_provider import call_llm
+from apply_operator.tools.pdf_parser import extract_text
+
+
+def _strip_markdown_json(text: str) -> str:
+    """Strip markdown code fences from LLM JSON responses."""
+    match = re.search(r"```(?:json)?\s*\n?(.*?)\n?\s*```", text, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    return text.strip()
 
 
 def parse_resume(state: ApplicationState) -> dict[str, Any]:
@@ -10,8 +25,16 @@ def parse_resume(state: ApplicationState) -> dict[str, Any]:
 
     Uses PyMuPDF for text extraction, then LLM for structured parsing.
     """
-    # TODO: Implement
-    # 1. Extract raw text with pdf_parser.extract_text(state.resume_path)
-    # 2. Use LLM to parse into ResumeData fields
-    # 3. Return {"resume": ResumeData(...)}
-    return {}
+    raw_text = extract_text(state.resume_path)
+    prompt = PARSE_RESUME.format(resume_text=raw_text)
+    
+    try:
+        response = call_llm(prompt)
+        cleaned = _strip_markdown_json(response)
+    
+        data = json.loads(cleaned)
+        resume = ResumeData(raw_text=raw_text, **data)
+    except (json.JSONDecodeError, ValidationError) as e:
+        resume = ResumeData(raw_text=raw_text)
+        return {"resume": resume, "errors": [*state.errors, f"Resume parse failed: {e}"]}
+    return {"resume": resume}

--- a/src/apply_operator/prompts/resume_analysis.py
+++ b/src/apply_operator/prompts/resume_analysis.py
@@ -6,10 +6,12 @@ Return a JSON object with these fields:
 - name: full name
 - email: email address
 - phone: phone number
-- skills: list of technical and professional skills
-- experience: list of objects with {title, company, duration, description}
-- education: list of objects with {degree, institution, year}
+- skills: list of ALL technical and professional skills mentioned
+- experience: list of ALL positions, each with {{title, company, duration, description}}
+- education: list of ALL entries, each with {{degree, institution, year}}
 - summary: 2-3 sentence professional summary
+
+If a field is not present in the resume, use null for that field.
 
 Resume text:
 {resume_text}

--- a/src/apply_operator/state.py
+++ b/src/apply_operator/state.py
@@ -2,11 +2,16 @@
 
 from typing import Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 
 
 class ResumeData(BaseModel):
-    """Structured data extracted from a resume PDF."""
+    """Structured data extracted from a resume PDF.
+
+    All fields except raw_text are optional — the LLM may return null
+    for missing sections. A pre-validator coerces None to the field default
+    so downstream code can always assume non-None values.
+    """
 
     raw_text: str = ""
     name: str = ""
@@ -16,6 +21,26 @@ class ResumeData(BaseModel):
     experience: list[dict[str, Any]] = Field(default_factory=list)
     education: list[dict[str, Any]] = Field(default_factory=list)
     summary: str = ""
+
+    @model_validator(mode="before")
+    @classmethod
+    def coerce_none_to_defaults(cls, values: Any) -> Any:
+        """Replace None values with field defaults so Pydantic doesn't reject them."""
+        if not isinstance(values, dict):
+            return values
+        defaults: dict[str, Any] = {
+            "name": "",
+            "email": "",
+            "phone": "",
+            "skills": [],
+            "experience": [],
+            "education": [],
+            "summary": "",
+        }
+        for field, default in defaults.items():
+            if values.get(field) is None:
+                values[field] = default
+        return values
 
 
 class JobListing(BaseModel):

--- a/src/apply_operator/tools/llm_provider.py
+++ b/src/apply_operator/tools/llm_provider.py
@@ -1,9 +1,14 @@
 """Configurable LLM provider factory."""
 
+import logging
+import time
+
 from langchain_core.language_models import BaseChatModel
 from pydantic import SecretStr
 
 from apply_operator.config import get_settings
+
+logger = logging.getLogger(__name__)
 
 
 def get_llm() -> BaseChatModel:
@@ -17,10 +22,11 @@ def get_llm() -> BaseChatModel:
     if settings.llm_provider == "openai":
         from langchain_openai import ChatOpenAI
 
-        return ChatOpenAI(
+        return ChatOpenAI(  # type: ignore[call-arg]
             model=settings.llm_model,
             api_key=SecretStr(settings.openai_api_key),
             temperature=0.3,
+            max_tokens=settings.llm_max_tokens,
         )
 
     if settings.llm_provider == "anthropic":
@@ -30,6 +36,7 @@ def get_llm() -> BaseChatModel:
             model_name=settings.llm_model,
             api_key=SecretStr(settings.anthropic_api_key),
             temperature=0.3,
+            max_tokens=settings.llm_max_tokens,
         )
 
     if settings.llm_provider == "google":
@@ -39,16 +46,18 @@ def get_llm() -> BaseChatModel:
             model=settings.llm_model,
             google_api_key=settings.google_api_key,
             temperature=0.3,
+            max_output_tokens=settings.llm_max_tokens,
         )
 
     if settings.llm_provider == "openrouter":
         from langchain_openai import ChatOpenAI
 
-        return ChatOpenAI(
+        return ChatOpenAI(  # type: ignore[call-arg]
             model=settings.llm_model,
             api_key=SecretStr(settings.openrouter_api_key),
             base_url=settings.openrouter_base_url,
             temperature=0.3,
+            max_tokens=settings.llm_max_tokens,
         )
 
     msg = f"Unknown LLM provider: {settings.llm_provider}"
@@ -60,6 +69,17 @@ def call_llm(prompt: str) -> str:
 
     Convenience wrapper around get_llm() that handles AIMessage extraction.
     """
+    settings = get_settings()
     llm = get_llm()
+
+    logger.info(
+        "LLM call starting | provider=%s model=%s",
+        settings.llm_provider,
+        settings.llm_model,
+    )
+    start = time.perf_counter()
     response = llm.invoke(prompt)
+    elapsed = time.perf_counter() - start
+    logger.info("LLM call finished | %.2fs", elapsed)
+
     return str(response.content)

--- a/tests/test_parse_resume.py
+++ b/tests/test_parse_resume.py
@@ -1,0 +1,172 @@
+"""Tests for the parse_resume node."""
+
+import json
+from typing import Any
+from unittest.mock import patch
+
+from apply_operator.nodes.parse_resume import _strip_markdown_json, parse_resume
+from apply_operator.state import ApplicationState, ResumeData
+
+VALID_LLM_RESPONSE = json.dumps(
+    {
+        "name": "John Doe",
+        "email": "john@example.com",
+        "phone": "555-0100",
+        "skills": ["Python", "TypeScript"],
+        "experience": [
+            {
+                "title": "Senior Engineer",
+                "company": "Acme Corp",
+                "duration": "2020-2024",
+                "description": "Led backend development",
+            }
+        ],
+        "education": [
+            {"degree": "BS Computer Science", "institution": "MIT", "year": "2020"}
+        ],
+        "summary": "Experienced software engineer.",
+    }
+)
+
+
+class TestStripMarkdownJson:
+    def test_strips_json_code_fence(self) -> None:
+        text = '```json\n{"name": "John"}\n```'
+        assert _strip_markdown_json(text) == '{"name": "John"}'
+
+    def test_strips_plain_code_fence(self) -> None:
+        text = '```\n{"name": "John"}\n```'
+        assert _strip_markdown_json(text) == '{"name": "John"}'
+
+    def test_returns_plain_json_unchanged(self) -> None:
+        text = '{"name": "John"}'
+        assert _strip_markdown_json(text) == '{"name": "John"}'
+
+    def test_strips_surrounding_whitespace(self) -> None:
+        text = '  {"name": "John"}  '
+        assert _strip_markdown_json(text) == '{"name": "John"}'
+
+
+class TestParseResume:
+    @patch("apply_operator.nodes.parse_resume.call_llm")
+    @patch("apply_operator.nodes.parse_resume.extract_text")
+    def test_parses_valid_json_response(
+        self, mock_extract: Any, mock_llm: Any
+    ) -> None:
+        mock_extract.return_value = "John Doe\njohn@example.com"
+        mock_llm.return_value = VALID_LLM_RESPONSE
+
+        state = ApplicationState(resume_path="resume.pdf")
+        result = parse_resume(state)
+
+        assert "resume" in result
+        assert "errors" not in result
+        resume: ResumeData = result["resume"]
+        assert resume.name == "John Doe"
+        assert resume.email == "john@example.com"
+        assert resume.phone == "555-0100"
+        assert resume.skills == ["Python", "TypeScript"]
+        assert len(resume.experience) == 1
+        assert len(resume.education) == 1
+        assert resume.summary == "Experienced software engineer."
+        assert resume.raw_text == "John Doe\njohn@example.com"
+
+    @patch("apply_operator.nodes.parse_resume.call_llm")
+    @patch("apply_operator.nodes.parse_resume.extract_text")
+    def test_handles_invalid_json(self, mock_extract: Any, mock_llm: Any) -> None:
+        mock_extract.return_value = "some resume text"
+        mock_llm.return_value = "not valid json at all"
+
+        state = ApplicationState(resume_path="resume.pdf")
+        result = parse_resume(state)
+
+        assert result["resume"].raw_text == "some resume text"
+        assert result["resume"].name == ""
+        assert len(result["errors"]) == 1
+        assert "Resume parse failed" in result["errors"][0]
+
+    @patch("apply_operator.nodes.parse_resume.call_llm")
+    @patch("apply_operator.nodes.parse_resume.extract_text")
+    def test_handles_markdown_wrapped_json(
+        self, mock_extract: Any, mock_llm: Any
+    ) -> None:
+        mock_extract.return_value = "John Doe\njohn@example.com"
+        mock_llm.return_value = f"```json\n{VALID_LLM_RESPONSE}\n```"
+
+        state = ApplicationState(resume_path="resume.pdf")
+        result = parse_resume(state)
+
+        assert "errors" not in result
+        assert result["resume"].name == "John Doe"
+
+    @patch("apply_operator.nodes.parse_resume.call_llm")
+    @patch("apply_operator.nodes.parse_resume.extract_text")
+    def test_handles_empty_resume_text(
+        self, mock_extract: Any, mock_llm: Any
+    ) -> None:
+        mock_extract.return_value = ""
+        mock_llm.return_value = json.dumps({"name": "", "email": "", "skills": []})
+
+        state = ApplicationState(resume_path="resume.pdf")
+        result = parse_resume(state)
+
+        assert result["resume"].raw_text == ""
+
+    @patch("apply_operator.nodes.parse_resume.call_llm")
+    @patch("apply_operator.nodes.parse_resume.extract_text")
+    def test_handles_null_fields(self, mock_extract: Any, mock_llm: Any) -> None:
+        mock_extract.return_value = "Jane Doe\nSoftware Engineer"
+        mock_llm.return_value = json.dumps(
+            {
+                "name": "Jane Doe",
+                "email": None,
+                "phone": None,
+                "skills": ["Python"],
+                "experience": None,
+                "education": None,
+                "summary": None,
+            }
+        )
+
+        state = ApplicationState(resume_path="resume.pdf")
+        result = parse_resume(state)
+
+        assert "errors" not in result
+        resume = result["resume"]
+        assert resume.name == "Jane Doe"
+        assert resume.email == ""
+        assert resume.phone == ""
+        assert resume.skills == ["Python"]
+        assert resume.experience == []
+        assert resume.education == []
+        assert resume.summary == ""
+
+    @patch("apply_operator.nodes.parse_resume.call_llm")
+    @patch("apply_operator.nodes.parse_resume.extract_text")
+    def test_handles_validation_error(
+        self, mock_extract: Any, mock_llm: Any
+    ) -> None:
+        mock_extract.return_value = "some text"
+        # skills should be a list, not a string — triggers ValidationError
+        mock_llm.return_value = json.dumps({"skills": 12345})
+
+        state = ApplicationState(resume_path="resume.pdf")
+        result = parse_resume(state)
+
+        assert result["resume"].raw_text == "some text"
+        assert len(result["errors"]) == 1
+        assert "Resume parse failed" in result["errors"][0]
+
+    @patch("apply_operator.nodes.parse_resume.call_llm")
+    @patch("apply_operator.nodes.parse_resume.extract_text")
+    def test_preserves_existing_errors(
+        self, mock_extract: Any, mock_llm: Any
+    ) -> None:
+        mock_extract.return_value = "text"
+        mock_llm.return_value = "bad json"
+
+        state = ApplicationState(resume_path="resume.pdf", errors=["prior error"])
+        result = parse_resume(state)
+
+        assert result["errors"][0] == "prior error"
+        assert "Resume parse failed" in result["errors"][1]


### PR DESCRIPTION
## Summary

- Implement `parse_resume` LangGraph node — extracts PDF text, sends to LLM, parses JSON into `ResumeData`
- Handle edge cases: markdown-wrapped JSON, null fields from LLM, validation errors
- Add Rich table CLI output, LLM execution time logging, and `llm_max_tokens` config

## Motivation

Resolves https://github.com/takeshi-su57/lucky-plan/issues/7

First LangGraph node in the pipeline. All downstream nodes (search_jobs, analyze_fit, fill_application) depend on structured resume data flowing through `ApplicationState`.

## Changes

- `src/apply_operator/nodes/parse_resume.py` — Implemented node with `_strip_markdown_json` helper for code-fenced responses
- `src/apply_operator/prompts/resume_analysis.py` — Refined prompt with escaped braces, null field instruction
- `src/apply_operator/main.py` — `parse-resume` CLI now shows Rich table with experience details and sentence counts; added logging setup
- `src/apply_operator/state.py` — `ResumeData` `model_validator` to coerce `None` → defaults (LLMs return null for missing fields)
- `src/apply_operator/config.py` — Added `llm_max_tokens` setting (default 8192)
- `src/apply_operator/tools/llm_provider.py` — Pass `max_tokens` to all providers; log provider, model, and execution time
- `tests/test_parse_resume.py` — 11 tests: markdown stripping, valid/invalid JSON, null fields, validation errors, error preservation

## How to Test

1. `uv run pytest tests/test_parse_resume.py -v` — all 11 tests pass
2. `uv run ruff check src/ tests/` — no lint errors
3. `uv run mypy src/` — no type errors
4. `uv run python -m apply_operator parse-resume --resume ./input/resume.pdf` — shows structured Rich table

## Checklist

- [x] Self-reviewed the code
- [x] Added/updated tests (11 new tests)
- [x] No new warnings or errors
- [x] `ruff check`, `mypy`, `pytest` all pass
- [x] Updated issue doc with implementation details
