### PR TITLE
feat(nodes): implement analyze_fit node with LLM scoring

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -97,6 +97,7 @@ playwright install         # Install browser binaries
 - `.claude/rules/gh-issue.md` — Issue title format, templates for bugs/features/chores
 - `.claude/rules/ai-framework.md` — Sync protocol, skill/rule design, maintenance
 - `.claude/rules/documentation.md` — Docs structure, ADR conventions
+- `.claude/rules/logging.md` — Log levels, node decorator, LLM call logging, format conventions
 
 ## Known Gaps
 

--- a/.claude/rules/logging.md
+++ b/.claude/rules/logging.md
@@ -1,0 +1,96 @@
+# Logging Rules
+
+How to log consistently across nodes, tools, and LLM calls.
+
+## Logger Setup
+
+Every module uses its own logger:
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+```
+
+Never use `print()` for operational output — use `logger` or Rich console (CLI only).
+
+## Log Levels
+
+| Level | When to use | Examples |
+|-------|-------------|---------|
+| `DEBUG` | Internal mechanics, polling, retries | Page content stable at 5000 chars, networkidle timed out |
+| `INFO` | Key pipeline milestones and results | Node entry/exit, LLM call start/finish, job scored, jobs found |
+| `WARNING` | Recoverable issues, fallback used | Bad JSON from LLM (defaulting to 0), pagination element not found |
+| `ERROR` | Failures that skip work | Node failed with exception, URL unreachable |
+
+## LangGraph Node Logging
+
+Every node must log entry and exit. Use the `log_node` decorator from `tools/logging_utils.py`:
+
+```python
+from apply_operator.tools.logging_utils import log_node
+
+@log_node
+def my_node(state: ApplicationState) -> dict[str, Any]:
+    ...
+```
+
+The decorator automatically logs:
+- `INFO` on entry: `node=my_node | started`
+- `INFO` on exit: `node=my_node | completed | 2.35s`
+- `ERROR` on exception: `node=my_node | failed | ValueError: ...`
+
+Inside the node, log meaningful business events:
+```python
+logger.info("Fit score for %s (%s): %.2f", job.title, job.company, score)
+```
+
+## LLM Call Logging
+
+Use the `purpose` parameter in `call_llm()` to describe what the call is for:
+
+```python
+response = call_llm(prompt, purpose="analyze_fit for Senior Engineer at TechCo")
+```
+
+The LLM provider logs:
+- `INFO` on start: `LLM call | provider=openrouter model=gpt-4o purpose=analyze_fit for Senior Engineer at TechCo`
+- `INFO` on finish: `LLM call | completed | 6.03s | ~1200 chars`
+
+## Browser Action Logging
+
+- `INFO`: Navigation (`goto`), login detection, session save
+- `DEBUG`: Page ready checks, content stability polling
+- `WARNING`: Page load timeouts, extraction failures
+
+## Format Convention
+
+Use pipe-delimited structured fields for machine-parseable logs:
+
+```python
+# Good — structured, scannable
+logger.info("node=%s | started", node_name)
+logger.info("LLM call | provider=%s model=%s purpose=%s", provider, model, purpose)
+logger.info("Fit score for %s (%s): %.2f — %s", title, company, score, reasoning)
+
+# Bad — unstructured prose
+logger.info("Starting to process the node now")
+logger.info("Called the LLM and got a response back")
+```
+
+## What NOT to Log
+
+- API keys, tokens, or credentials at any level
+- Full resume text or personal data at INFO (use DEBUG only)
+- Full LLM prompts at INFO (use DEBUG)
+- Full LLM responses at INFO (log summary: char count, parsed score, etc.)
+- Redundant "about to call X" then "calling X" then "called X" — one start + one finish is enough
+
+## Checklist for New Code
+
+- [ ] Module has `logger = logging.getLogger(__name__)`
+- [ ] Node function uses `@log_node` decorator
+- [ ] LLM calls pass `purpose=` parameter
+- [ ] Business events logged at INFO (scores, counts, decisions)
+- [ ] Errors caught and logged before appending to `state.errors`
+- [ ] No sensitive data in INFO-level logs

--- a/docs/issues/007-analyze-fit-node.md
+++ b/docs/issues/007-analyze-fit-node.md
@@ -13,50 +13,78 @@ Implement the `analyze_fit` node that uses the LLM to score how well the parsed 
 - LLM-based scoring is more nuanced than keyword matching
 - This node drives the graph's conditional routing (apply vs. skip)
 
-## Proposed Solution
+## Implementation
+
+### analyze_fit node (`nodes/analyze_fit.py`)
 
 1. Get current job from `state.jobs[state.current_job_index]`
-2. Build prompt with resume data + job description using `ANALYZE_FIT`
-3. Call LLM, parse `{"score": 0.85, "reasoning": "..."}` response
-4. Update the current job's `fit_score` and advance `current_job_index`
-
-### Key challenge: updating a list item
+2. Build prompt with resume data + job description using `ANALYZE_FIT` template
+3. Call LLM via `call_llm()`, parse `{"score": 0.85, "reasoning": "..."}` JSON response
+4. Clamp score to 0.0–1.0 range
+5. Update the current job's `fit_score` — does **not** advance `current_job_index`
 
 ```python
 updated_jobs = list(state.jobs)
-updated_jobs[idx] = state.jobs[idx].model_copy(update={"fit_score": score})
-return {"jobs": updated_jobs, "current_job_index": idx + 1}
+updated_jobs[idx] = job.model_copy(update={"fit_score": score})
+return {"jobs": updated_jobs}
 ```
 
-### Graph routing (already in graph.py)
+On invalid JSON: defaults to score 0.0 and appends error to `state.errors`.
 
-- `fit_score >= 0.6` → `fill_application`
-- `fit_score < 0.6` → skip (advance index, back to `analyze_fit`)
-- `current_job_index >= len(jobs)` → `report_results`
+### Graph routing fix (`graph.py`)
 
-**Important:** The index must advance in every path (apply AND skip) to prevent infinite loops.
+The original design had `analyze_fit` advancing `current_job_index` and the `"skip"` edge looping back to `analyze_fit`. This caused `should_apply` to check the **next** (unscored) job instead of the just-scored one, making the "apply" path unreachable.
+
+**Fix:** `analyze_fit` only scores (no index advancement). A new `skip_job` node handles index advancement and skip counting for the low-score path.
+
+```
+analyze_fit → should_apply →
+  "apply"  → fill_application → has_more_jobs → analyze_fit or report_results
+  "skip"   → skip_job → analyze_fit
+  "report" → report_results
+```
+
+### Additional fixes discovered during implementation
+
+- **`main.py` _print_results crash** — used `.get()` (dict API) on `JobListing` Pydantic objects returned by LangGraph. Fixed to handle both dicts and Pydantic objects.
+- **`browser.py` stale tests (11 failures)** — `test_browser.py` and `test_search_jobs.py` had tests written against a removed `_get_browser_headed` API, old JSON session storage, and outdated call signatures. All 11 tests updated to match current production code.
+- **Page rendering race condition** — job sites with JS-rendered content (skeleton screens, lazy-loaded lists) returned 0 jobs because content extraction happened before rendering completed. Added `wait_for_page_ready()` helper that waits for network idle + content stability.
+- **Logging framework** — added `@log_node` decorator for consistent node entry/exit/duration logging, and `purpose=` parameter to `call_llm()` for contextual LLM call logs. Created `.claude/rules/logging.md` to codify conventions.
 
 ## Alternatives Considered
 
 - **Keyword matching** — fast but misses context (e.g., "Python" might mean snake care, not programming)
 - **Embedding similarity** — more complex setup, requires vector DB; LLM scoring is simpler for v1
+- **Index advancement in analyze_fit** — original design; caused routing bug where `should_apply` always saw unscored jobs
 
 ## Acceptance Criteria
 
-- [ ] Node scores resume against job and stores `fit_score` in `JobListing`
-- [ ] `current_job_index` advances correctly for both apply and skip paths
-- [ ] Invalid LLM response (bad JSON) defaults to score 0.0 with error logged
-- [ ] Score outside 0-1 range is clamped
-- [ ] Out-of-bounds index returns immediately (no crash)
-- [ ] Tests pass with mocked LLM
-- [ ] `ruff check` and `mypy` pass
+- [x] Node scores resume against job and stores `fit_score` in `JobListing`
+- [x] `current_job_index` advances correctly for both apply and skip paths
+- [x] Invalid LLM response (bad JSON) defaults to score 0.0 with error logged
+- [x] Score outside 0-1 range is clamped
+- [x] Out-of-bounds index returns immediately (no crash)
+- [x] Tests pass with mocked LLM (18 tests for analyze_fit + routing)
+- [x] `ruff check` and `mypy` pass
+- [x] All 81 tests pass (including fixed pre-existing failures)
 
 ## Files Touched
 
-- `src/apply_operator/nodes/analyze_fit.py` — implement
-- `src/apply_operator/prompts/job_matching.py` — refine `ANALYZE_FIT` if needed
-- `src/apply_operator/graph.py` — verify index advancement logic
-- `tests/test_analyze_fit.py` — create
+- `src/apply_operator/nodes/analyze_fit.py` — full implementation with LLM scoring
+- `src/apply_operator/graph.py` — added `skip_job` node, fixed routing logic
+- `src/apply_operator/main.py` — fixed `_print_results` Pydantic object handling
+- `src/apply_operator/tools/browser.py` — added `wait_for_page_ready()`, removed unused import
+- `src/apply_operator/tools/llm_provider.py` — added `purpose=` parameter to `call_llm()`
+- `src/apply_operator/tools/logging_utils.py` — new `@log_node` decorator
+- `src/apply_operator/nodes/parse_resume.py` — added `@log_node`, `purpose=`
+- `src/apply_operator/nodes/search_jobs.py` — added `@log_node`, `purpose=`, `wait_for_page_ready()`
+- `src/apply_operator/nodes/fill_application.py` — added `@log_node`
+- `src/apply_operator/nodes/report_results.py` — added `@log_node`, result summary logging
+- `.claude/CLAUDE.md` — added logging rule reference
+- `.claude/rules/logging.md` — new logging conventions rule
+- `tests/test_analyze_fit.py` — new (18 tests)
+- `tests/test_browser.py` — fixed 10 stale tests
+- `tests/test_search_jobs.py` — fixed 1 stale test
 
 ## Related Issues
 

--- a/src/apply_operator/graph.py
+++ b/src/apply_operator/graph.py
@@ -1,5 +1,7 @@
 """LangGraph StateGraph assembly for the job application agent."""
 
+from typing import Any
+
 from langgraph.graph import END, StateGraph
 from langgraph.graph.state import CompiledStateGraph
 
@@ -12,11 +14,16 @@ from apply_operator.state import ApplicationState
 
 
 def should_apply(state: ApplicationState) -> str:
-    """Route based on fit score: apply or skip to next job."""
-    if state.current_job_index >= len(state.jobs):
+    """Route based on fit score: apply or skip to next job.
+
+    analyze_fit scores the job at current_job_index without advancing.
+    This function checks that scored job and routes accordingly.
+    """
+    idx = state.current_job_index
+    if idx >= len(state.jobs):
         return "report"
 
-    current_job = state.jobs[state.current_job_index]
+    current_job = state.jobs[idx]
     if current_job.fit_score >= 0.6:
         return "apply"
     return "skip"
@@ -29,13 +36,21 @@ def has_more_jobs(state: ApplicationState) -> str:
     return "done"
 
 
+def skip_job(state: ApplicationState) -> dict[str, Any]:
+    """Advance past a low-scoring job, incrementing the skip counter."""
+    return {
+        "current_job_index": state.current_job_index + 1,
+        "total_skipped": state.total_skipped + 1,
+    }
+
+
 def build_graph() -> CompiledStateGraph:  # type: ignore[type-arg]
     """Build and return the compiled job application agent graph.
 
     Flow:
         START -> parse_resume -> search_jobs -> analyze_fit
-            -> [fit >= 0.6] -> fill_application -> advance -> analyze_fit (loop)
-            -> [fit < 0.6] -> advance -> analyze_fit (loop)
+            -> [fit >= 0.6] -> fill_application -> (loop or report)
+            -> [fit < 0.6] -> skip_job -> analyze_fit (loop)
             -> [no more jobs] -> report_results -> END
     """
     graph = StateGraph(ApplicationState)
@@ -44,6 +59,7 @@ def build_graph() -> CompiledStateGraph:  # type: ignore[type-arg]
     graph.add_node("parse_resume", parse_resume)
     graph.add_node("search_jobs", search_jobs)
     graph.add_node("analyze_fit", analyze_fit)
+    graph.add_node("skip_job", skip_job)
     graph.add_node("fill_application", fill_application)
     graph.add_node("report_results", report_results)
 
@@ -52,16 +68,19 @@ def build_graph() -> CompiledStateGraph:  # type: ignore[type-arg]
     graph.add_edge("parse_resume", "search_jobs")
     graph.add_edge("search_jobs", "analyze_fit")
 
-    # Conditional: analyze_fit -> apply or skip
+    # Conditional: analyze_fit -> apply, skip, or report
     graph.add_conditional_edges(
         "analyze_fit",
         should_apply,
         {
             "apply": "fill_application",
-            "skip": "analyze_fit",  # advance index and re-enter
+            "skip": "skip_job",
             "report": "report_results",
         },
     )
+
+    # skip_job advances index and loops back to analyze next job
+    graph.add_edge("skip_job", "analyze_fit")
 
     # After application, loop back to analyze next job
     graph.add_conditional_edges(

--- a/src/apply_operator/main.py
+++ b/src/apply_operator/main.py
@@ -124,14 +124,19 @@ def _print_results(state: dict[str, Any]) -> None:
     table.add_column("Status", style="yellow")
 
     for job in state.get("jobs", []):
-        status = "Applied" if job.get("applied") else "Skipped"
-        error = job.get("error", "")
+        title = job.title if hasattr(job, "title") else job.get("title", "Unknown")
+        company = job.company if hasattr(job, "company") else job.get("company", "Unknown")
+        fit_score = job.fit_score if hasattr(job, "fit_score") else job.get("fit_score", 0)
+        applied = job.applied if hasattr(job, "applied") else job.get("applied", False)
+        error = job.error if hasattr(job, "error") else job.get("error", "")
+
+        status = "Applied" if applied else "Skipped"
         if error:
             status = f"Error: {error}"
         table.add_row(
-            job.get("title", "Unknown"),
-            job.get("company", "Unknown"),
-            f"{job.get('fit_score', 0):.0%}",
+            title or "Unknown",
+            company or "Unknown",
+            f"{fit_score:.0%}",
             status,
         )
 

--- a/src/apply_operator/nodes/analyze_fit.py
+++ b/src/apply_operator/nodes/analyze_fit.py
@@ -1,24 +1,103 @@
 """Node: Analyze fit between resume and current job listing."""
 
+import json
+import logging
+import re
 from typing import Any
 
+from apply_operator.prompts.job_matching import ANALYZE_FIT
 from apply_operator.state import ApplicationState
+from apply_operator.tools.llm_provider import call_llm
+from apply_operator.tools.logging_utils import log_node
+
+logger = logging.getLogger(__name__)
 
 
+def _strip_markdown_json(text: str) -> str:
+    """Strip markdown code fences from LLM JSON responses."""
+    match = re.search(r"```(?:json)?\s*\n?(.*?)\n?\s*```", text, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    return text.strip()
+
+
+def _format_experience(experience: list[dict[str, Any]]) -> str:
+    """Format experience list into a readable string for the prompt."""
+    if not experience:
+        return "No experience listed"
+    parts = []
+    for exp in experience:
+        title = exp.get("title", "Unknown")
+        company = exp.get("company", "Unknown")
+        duration = exp.get("duration", "")
+        desc = exp.get("description", "")
+        entry = f"{title} at {company}"
+        if duration:
+            entry += f" ({duration})"
+        if desc:
+            entry += f" — {desc}"
+        parts.append(entry)
+    return "; ".join(parts)
+
+
+@log_node
 def analyze_fit(state: ApplicationState) -> dict[str, Any]:
     """Use LLM to score how well the resume matches the current job.
 
-    Returns a fit score (0.0 to 1.0) for the current job listing.
+    Scores the job at current_job_index without advancing the index.
+    The graph's conditional edges handle routing (apply/skip/report).
     """
-    # TODO: Implement LLM-based fit scoring
-    # For now, skip all jobs by advancing the index
     idx = state.current_job_index
     if idx >= len(state.jobs):
         return {}
-    jobs = list(state.jobs)
-    jobs[idx] = jobs[idx].model_copy(update={"fit_score": 0.0})
-    return {
-        "jobs": jobs,
-        "current_job_index": idx + 1,
-        "total_skipped": state.total_skipped + 1,
-    }
+
+    job = state.jobs[idx]
+
+    prompt = ANALYZE_FIT.format(
+        name=state.resume.name,
+        skills=", ".join(state.resume.skills) if state.resume.skills else "None listed",
+        experience=_format_experience(state.resume.experience),
+        job_title=job.title,
+        company=job.company,
+        job_description=job.description,
+    )
+
+    score = 0.0
+    reasoning = ""
+    errors = list(state.errors)
+
+    try:
+        response = call_llm(prompt, purpose=f"analyze_fit for {job.title} at {job.company}")
+        cleaned = _strip_markdown_json(response)
+        data = json.loads(cleaned)
+
+        raw_score = float(data.get("score", 0.0))
+        score = max(0.0, min(1.0, raw_score))
+        reasoning = str(data.get("reasoning", ""))
+
+        if raw_score != score:
+            logger.warning(
+                "Fit score %.2f clamped to %.2f for %s",
+                raw_score,
+                score,
+                job.url,
+            )
+    except (json.JSONDecodeError, ValueError, TypeError, KeyError) as e:
+        logger.error("Failed to parse LLM fit response for %s: %s", job.url, e)
+        errors.append(f"Fit analysis failed for {job.url}: {e}")
+
+    logger.info(
+        "Fit score for %s (%s): %.2f — %s",
+        job.title,
+        job.company,
+        score,
+        reasoning or "no reasoning",
+    )
+
+    updated_jobs = list(state.jobs)
+    updated_jobs[idx] = job.model_copy(update={"fit_score": score})
+
+    result: dict[str, Any] = {"jobs": updated_jobs}
+    if errors != list(state.errors):
+        result["errors"] = errors
+    return result

--- a/src/apply_operator/nodes/fill_application.py
+++ b/src/apply_operator/nodes/fill_application.py
@@ -3,8 +3,10 @@
 from typing import Any
 
 from apply_operator.state import ApplicationState
+from apply_operator.tools.logging_utils import log_node
 
 
+@log_node
 def fill_application(state: ApplicationState) -> dict[str, Any]:
     """Use Playwright + LLM to fill out the job application form.
 

--- a/src/apply_operator/nodes/parse_resume.py
+++ b/src/apply_operator/nodes/parse_resume.py
@@ -9,6 +9,7 @@ from pydantic import ValidationError
 from apply_operator.prompts.resume_analysis import PARSE_RESUME
 from apply_operator.state import ApplicationState, ResumeData
 from apply_operator.tools.llm_provider import call_llm
+from apply_operator.tools.logging_utils import log_node
 from apply_operator.tools.pdf_parser import extract_text
 
 
@@ -20,6 +21,7 @@ def _strip_markdown_json(text: str) -> str:
     return text.strip()
 
 
+@log_node
 def parse_resume(state: ApplicationState) -> dict[str, Any]:
     """Extract text from resume PDF and parse into structured fields.
 
@@ -29,7 +31,7 @@ def parse_resume(state: ApplicationState) -> dict[str, Any]:
     prompt = PARSE_RESUME.format(resume_text=raw_text)
 
     try:
-        response = call_llm(prompt)
+        response = call_llm(prompt, purpose="parse_resume")
         cleaned = _strip_markdown_json(response)
 
         data = json.loads(cleaned)

--- a/src/apply_operator/nodes/report_results.py
+++ b/src/apply_operator/nodes/report_results.py
@@ -1,12 +1,17 @@
 """Node: Generate final report of all application results."""
 
 import json
+import logging
 from pathlib import Path
 from typing import Any
 
 from apply_operator.state import ApplicationState
+from apply_operator.tools.logging_utils import log_node
+
+logger = logging.getLogger(__name__)
 
 
+@log_node
 def report_results(state: ApplicationState) -> dict[str, Any]:
     """Save results to JSON and print summary.
 
@@ -22,5 +27,12 @@ def report_results(state: ApplicationState) -> dict[str, Any]:
     output_path = Path("data/results.json")
     output_path.parent.mkdir(parents=True, exist_ok=True)
     output_path.write_text(json.dumps(results, indent=2))
+    logger.info(
+        "Results saved to %s | applied=%d skipped=%d errors=%d",
+        output_path,
+        state.total_applied,
+        state.total_skipped,
+        len(state.errors),
+    )
 
     return {}

--- a/src/apply_operator/nodes/search_jobs.py
+++ b/src/apply_operator/nodes/search_jobs.py
@@ -10,8 +10,14 @@ from playwright.async_api import Page
 from apply_operator.config import get_settings
 from apply_operator.prompts.job_matching import EXTRACT_JOBS
 from apply_operator.state import ApplicationState, JobListing
-from apply_operator.tools.browser import get_page_text, get_page_with_session, wait_for_user
+from apply_operator.tools.browser import (
+    get_page_text,
+    get_page_with_session,
+    wait_for_page_ready,
+    wait_for_user,
+)
 from apply_operator.tools.llm_provider import call_llm
+from apply_operator.tools.logging_utils import log_node
 
 logger = logging.getLogger(__name__)
 
@@ -53,7 +59,7 @@ async def _extract_jobs_from_page(page: Page, url: str) -> list[JobListing]:
         return []
 
     prompt = EXTRACT_JOBS.format(page_text=text[:8000], url=url)
-    response = call_llm(prompt)
+    response = call_llm(prompt, purpose=f"extract_jobs from {url}")
     cleaned = _strip_markdown_json(response)
 
     try:
@@ -90,12 +96,14 @@ async def _find_next_page(page: Page) -> bool:
             if element and await element.is_visible():
                 await element.click()
                 await page.wait_for_load_state("domcontentloaded")
+                await wait_for_page_ready(page)
                 return True
         except Exception:
             continue
     return False
 
 
+@log_node
 async def search_jobs(state: ApplicationState) -> dict[str, Any]:
     """Navigate to job site URLs and scrape job listings.
 
@@ -117,9 +125,11 @@ async def search_jobs(state: ApplicationState) -> dict[str, Any]:
                     wait_until="domcontentloaded",
                 )
 
+                await wait_for_page_ready(page)
                 logger.info("Page loaded, checking for login wall")
                 if await _detect_login_required(page):
                     await wait_for_user(page, f"Login required at {url}. Please log in.")
+                    await wait_for_page_ready(page)
 
                 logger.info("Extracting jobs from %s", url)
                 while True:

--- a/src/apply_operator/tools/browser.py
+++ b/src/apply_operator/tools/browser.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from typing import TypedDict
 from urllib.parse import urlparse
 
-from playwright.async_api import Browser, BrowserContext, Page, async_playwright
+from playwright.async_api import Browser, Page, async_playwright
 from rich.console import Console
 
 from apply_operator.config import get_settings
@@ -97,6 +97,54 @@ async def get_page_with_session(url: str) -> AsyncGenerator[Page, None]:
         finally:
             await context.close()
             logger.info("Session saved to %s", user_data_dir)
+
+
+async def wait_for_page_ready(
+    page: Page,
+    *,
+    settle_ms: int = 500,
+    timeout_ms: int = 10000,
+) -> None:
+    """Wait for a page to finish rendering dynamic content.
+
+    Strategy:
+    1. Wait for network idle (no in-flight requests for 500ms).
+    2. Poll page text length until it stabilizes — catches skeleton screens,
+       lazy-loaded lists, and JS-rendered content that appears after network idle.
+
+    Args:
+        page: Playwright page to wait on.
+        settle_ms: How long (ms) the text length must stay unchanged to consider
+            the page stable. Default 500ms.
+        timeout_ms: Maximum total wait time. Default 10s.
+    """
+    # Step 1: wait for network to quiet down
+    try:
+        await page.wait_for_load_state("networkidle", timeout=timeout_ms)
+    except Exception:
+        logger.debug("networkidle timed out, proceeding to content stability check")
+
+    # Step 2: poll text length until stable
+    prev_length = 0
+    stable_since = 0.0
+    elapsed = 0.0
+    poll_interval = 0.25  # seconds
+
+    while elapsed < timeout_ms / 1000:
+        text = await page.evaluate("() => (document.body.innerText || '').length")
+        now = asyncio.get_event_loop().time()
+
+        if text != prev_length:
+            prev_length = text
+            stable_since = now
+        elif (now - stable_since) >= settle_ms / 1000:
+            logger.debug("Page content stable at %d chars after %.1fs", text, elapsed)
+            return
+
+        await asyncio.sleep(poll_interval)
+        elapsed += poll_interval
+
+    logger.debug("Page ready timeout after %.1fs, proceeding with %d chars", elapsed, prev_length)
 
 
 async def wait_for_user(page: Page, message: str) -> None:

--- a/src/apply_operator/tools/llm_provider.py
+++ b/src/apply_operator/tools/llm_provider.py
@@ -64,22 +64,30 @@ def get_llm() -> BaseChatModel:
     raise ValueError(msg)
 
 
-def call_llm(prompt: str) -> str:
+def call_llm(prompt: str, *, purpose: str = "") -> str:
     """Call the configured LLM with a prompt and return the response text.
 
     Convenience wrapper around get_llm() that handles AIMessage extraction.
+
+    Args:
+        prompt: The prompt to send to the LLM.
+        purpose: Short description of why this call is being made (for logging).
     """
     settings = get_settings()
     llm = get_llm()
 
+    purpose_str = f" purpose={purpose}" if purpose else ""
     logger.info(
-        "LLM call starting | provider=%s model=%s",
+        "LLM call | provider=%s model=%s%s",
         settings.llm_provider,
         settings.llm_model,
+        purpose_str,
     )
+    logger.debug("LLM prompt | %d chars", len(prompt))
     start = time.perf_counter()
     response = llm.invoke(prompt)
     elapsed = time.perf_counter() - start
-    logger.info("LLM call finished | %.2fs", elapsed)
+    content = str(response.content)
+    logger.info("LLM call | completed | %.2fs | ~%d chars", elapsed, len(content))
 
-    return str(response.content)
+    return content

--- a/src/apply_operator/tools/logging_utils.py
+++ b/src/apply_operator/tools/logging_utils.py
@@ -1,0 +1,59 @@
+"""Logging utilities for LangGraph node instrumentation."""
+
+import functools
+import inspect
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def log_node(func: Any) -> Any:
+    """Decorator that logs node entry, exit, and duration.
+
+    Works with both sync and async node functions.
+    Logs at INFO level on success, ERROR on exception.
+    The exception is re-raised after logging.
+    """
+    node_name = func.__name__
+
+    if inspect.iscoroutinefunction(func):
+
+        @functools.wraps(func)
+        async def async_wrapper(state: Any) -> dict[str, Any]:
+            logger.info("node=%s | started", node_name)
+            start = time.perf_counter()
+            try:
+                result: dict[str, Any] = await func(state)
+                elapsed = time.perf_counter() - start
+                logger.info("node=%s | completed | %.2fs", node_name, elapsed)
+                return result
+            except Exception as e:
+                elapsed = time.perf_counter() - start
+                logger.error(
+                    "node=%s | failed | %.2fs | %s: %s",
+                    node_name, elapsed, type(e).__name__, e,
+                )
+                raise
+
+        return async_wrapper
+
+    @functools.wraps(func)
+    def sync_wrapper(state: Any) -> dict[str, Any]:
+        logger.info("node=%s | started", node_name)
+        start = time.perf_counter()
+        try:
+            result: dict[str, Any] = func(state)
+            elapsed = time.perf_counter() - start
+            logger.info("node=%s | completed | %.2fs", node_name, elapsed)
+            return result
+        except Exception as e:
+            elapsed = time.perf_counter() - start
+            logger.error(
+                "node=%s | failed | %.2fs | %s: %s",
+                node_name, elapsed, type(e).__name__, e,
+            )
+            raise
+
+    return sync_wrapper

--- a/tests/test_analyze_fit.py
+++ b/tests/test_analyze_fit.py
@@ -1,0 +1,235 @@
+"""Tests for the analyze_fit node."""
+
+from typing import Any
+from unittest.mock import patch
+
+from apply_operator.nodes.analyze_fit import analyze_fit
+from apply_operator.state import ApplicationState, JobListing, ResumeData
+
+
+class TestAnalyzeFit:
+    """Tests for analyze_fit node function."""
+
+    def _make_state(
+        self,
+        jobs: list[JobListing] | None = None,
+        current_job_index: int = 0,
+        errors: list[str] | None = None,
+    ) -> ApplicationState:
+        resume = ResumeData(
+            raw_text="Jane Smith\nPython Developer",
+            name="Jane Smith",
+            skills=["Python", "Django", "PostgreSQL"],
+            experience=[
+                {
+                    "title": "Backend Engineer",
+                    "company": "Acme",
+                    "duration": "2021-2024",
+                    "description": "Built APIs",
+                }
+            ],
+            summary="Experienced backend developer.",
+        )
+        if jobs is None:
+            jobs = [
+                JobListing(
+                    url="https://example.com/jobs/1",
+                    title="Python Developer",
+                    company="TechCo",
+                    description="Looking for a Python developer with Django experience.",
+                ),
+            ]
+        return ApplicationState(
+            resume=resume,
+            jobs=jobs,
+            current_job_index=current_job_index,
+            errors=errors or [],
+        )
+
+    @patch("apply_operator.nodes.analyze_fit.call_llm")
+    def test_scores_job_with_valid_response(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '{"score": 0.85, "reasoning": "Strong Python match"}'
+        state = self._make_state()
+
+        result = analyze_fit(state)
+
+        assert result["jobs"][0].fit_score == 0.85
+        assert "errors" not in result
+
+    @patch("apply_operator.nodes.analyze_fit.call_llm")
+    def test_does_not_advance_index(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '{"score": 0.85, "reasoning": "Good match"}'
+        state = self._make_state()
+
+        result = analyze_fit(state)
+
+        assert "current_job_index" not in result
+
+    @patch("apply_operator.nodes.analyze_fit.call_llm")
+    def test_clamps_score_above_one(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '{"score": 1.5, "reasoning": "Off the charts"}'
+        state = self._make_state()
+
+        result = analyze_fit(state)
+
+        assert result["jobs"][0].fit_score == 1.0
+
+    @patch("apply_operator.nodes.analyze_fit.call_llm")
+    def test_clamps_score_below_zero(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '{"score": -0.3, "reasoning": "Terrible fit"}'
+        state = self._make_state()
+
+        result = analyze_fit(state)
+
+        assert result["jobs"][0].fit_score == 0.0
+
+    @patch("apply_operator.nodes.analyze_fit.call_llm")
+    def test_invalid_json_defaults_to_zero(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = "This is not JSON at all"
+        state = self._make_state()
+
+        result = analyze_fit(state)
+
+        assert result["jobs"][0].fit_score == 0.0
+        assert any("Fit analysis failed" in e for e in result["errors"])
+
+    @patch("apply_operator.nodes.analyze_fit.call_llm")
+    def test_missing_score_field_defaults_to_zero(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '{"reasoning": "No score provided"}'
+        state = self._make_state()
+
+        result = analyze_fit(state)
+
+        assert result["jobs"][0].fit_score == 0.0
+
+    @patch("apply_operator.nodes.analyze_fit.call_llm")
+    def test_markdown_wrapped_json(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '```json\n{"score": 0.7, "reasoning": "Good"}\n```'
+        state = self._make_state()
+
+        result = analyze_fit(state)
+
+        assert result["jobs"][0].fit_score == 0.7
+
+    def test_out_of_bounds_index_returns_empty(self) -> None:
+        state = self._make_state(current_job_index=5)
+
+        result = analyze_fit(state)
+
+        assert result == {}
+
+    def test_empty_jobs_list_returns_empty(self) -> None:
+        state = self._make_state(jobs=[], current_job_index=0)
+
+        result = analyze_fit(state)
+
+        assert result == {}
+
+    @patch("apply_operator.nodes.analyze_fit.call_llm")
+    def test_scores_correct_job_by_index(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '{"score": 0.9, "reasoning": "Great"}'
+        jobs = [
+            JobListing(url="https://example.com/1", title="Job A", company="Co A"),
+            JobListing(url="https://example.com/2", title="Job B", company="Co B"),
+        ]
+        state = self._make_state(jobs=jobs, current_job_index=1)
+
+        result = analyze_fit(state)
+
+        assert result["jobs"][0].fit_score == 0.0  # unchanged
+        assert result["jobs"][1].fit_score == 0.9  # scored
+
+    @patch("apply_operator.nodes.analyze_fit.call_llm")
+    def test_preserves_existing_errors(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = "not json"
+        state = self._make_state(errors=["previous error"])
+
+        result = analyze_fit(state)
+
+        assert "previous error" in result["errors"]
+        assert len(result["errors"]) == 2
+
+    @patch("apply_operator.nodes.analyze_fit.call_llm")
+    def test_prompt_includes_resume_and_job_data(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '{"score": 0.5, "reasoning": "OK"}'
+        state = self._make_state()
+
+        analyze_fit(state)
+
+        prompt = mock_call_llm.call_args[0][0]
+        assert "Jane Smith" in prompt
+        assert "Python" in prompt
+        assert "TechCo" in prompt
+        assert "Python Developer" in prompt
+
+
+class TestSkipJob:
+    """Tests for the skip_job graph helper."""
+
+    def test_advances_index_and_increments_skipped(self) -> None:
+        from apply_operator.graph import skip_job
+
+        state = ApplicationState(
+            jobs=[
+                JobListing(url="https://example.com/1", fit_score=0.3),
+                JobListing(url="https://example.com/2"),
+            ],
+            current_job_index=0,
+            total_skipped=0,
+        )
+
+        result = skip_job(state)
+
+        assert result["current_job_index"] == 1
+        assert result["total_skipped"] == 1
+
+
+class TestShouldApply:
+    """Tests for the should_apply routing function."""
+
+    def test_routes_apply_for_high_score(self) -> None:
+        from apply_operator.graph import should_apply
+
+        state = ApplicationState(
+            jobs=[JobListing(url="https://example.com/1", fit_score=0.8)],
+            current_job_index=0,
+        )
+
+        assert should_apply(state) == "apply"
+
+    def test_routes_skip_for_low_score(self) -> None:
+        from apply_operator.graph import should_apply
+
+        state = ApplicationState(
+            jobs=[JobListing(url="https://example.com/1", fit_score=0.3)],
+            current_job_index=0,
+        )
+
+        assert should_apply(state) == "skip"
+
+    def test_routes_apply_at_threshold(self) -> None:
+        from apply_operator.graph import should_apply
+
+        state = ApplicationState(
+            jobs=[JobListing(url="https://example.com/1", fit_score=0.6)],
+            current_job_index=0,
+        )
+
+        assert should_apply(state) == "apply"
+
+    def test_routes_report_when_all_processed(self) -> None:
+        from apply_operator.graph import should_apply
+
+        state = ApplicationState(
+            jobs=[JobListing(url="https://example.com/1", fit_score=0.8)],
+            current_job_index=1,
+        )
+
+        assert should_apply(state) == "report"
+
+    def test_routes_report_for_empty_jobs(self) -> None:
+        from apply_operator.graph import should_apply
+
+        state = ApplicationState(jobs=[], current_job_index=0)
+
+        assert should_apply(state) == "report"

--- a/tests/test_browser.py
+++ b/tests/test_browser.py
@@ -1,6 +1,5 @@
 """Tests for browser automation tools."""
 
-import json
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -21,19 +20,19 @@ class TestSessionPath:
 
     def test_returns_path_for_simple_url(self) -> None:
         result = session_path("https://linkedin.com/jobs")
-        assert result == Path("data/sessions/linkedin.com.json")
+        assert result == Path("data/sessions/linkedin.com")
 
     def test_handles_url_with_port(self) -> None:
         result = session_path("http://localhost:8080/page")
-        assert result == Path("data/sessions/localhost:8080.json")
+        assert result == Path("data/sessions/localhost:8080")
 
     def test_handles_subdomain(self) -> None:
         result = session_path("https://jobs.lever.co/company")
-        assert result == Path("data/sessions/jobs.lever.co.json")
+        assert result == Path("data/sessions/jobs.lever.co")
 
     def test_handles_url_with_path_and_query(self) -> None:
         result = session_path("https://example.com/path?q=1")
-        assert result == Path("data/sessions/example.com.json")
+        assert result == Path("data/sessions/example.com")
 
 
 class TestGetBrowser:
@@ -55,7 +54,11 @@ class TestGetBrowser:
         async with get_browser() as browser:
             assert browser is mock_browser
 
-        mock_pw.chromium.launch.assert_called_once_with(headless=True)
+        mock_pw.chromium.launch.assert_called_once_with(
+            headless=True,
+            channel="chrome",
+            args=["--disable-blink-features=AutomationControlled"],
+        )
 
     @patch("apply_operator.tools.browser.get_settings")
     @patch("apply_operator.tools.browser.async_playwright")
@@ -105,113 +108,112 @@ class TestGetPage:
 
 
 class TestGetPageWithSession:
-    """Tests for get_page_with_session context manager."""
+    """Tests for get_page_with_session context manager.
 
-    @patch("apply_operator.tools.browser._get_browser_headed")
-    async def test_loads_existing_session(
-        self, mock_browser_headed: MagicMock, tmp_path: Path
+    The implementation uses Playwright's launch_persistent_context with a
+    per-domain user data directory. Sessions are preserved by the browser
+    profile, not by explicit JSON storage_state files.
+    """
+
+    @patch("apply_operator.tools.browser.async_playwright")
+    async def test_launches_persistent_context_with_domain_dir(
+        self, mock_playwright: MagicMock, tmp_path: Path
     ) -> None:
-        # Create a session file
-        session_file = tmp_path / "example.com.json"
-        session_data = {"cookies": [{"name": "sid", "value": "abc"}]}
-        session_file.write_text(json.dumps(session_data))
-
-        mock_browser = AsyncMock()
+        user_data_dir = tmp_path / "example.com"
         mock_context = AsyncMock()
         mock_page = AsyncMock()
-        mock_browser.new_context.return_value = mock_context
-        mock_context.new_page.return_value = mock_page
-        mock_context.storage_state.return_value = session_data
-        mock_browser_headed.return_value.__aenter__.return_value = mock_browser
+        mock_context.pages = [mock_page]
 
-        with patch("apply_operator.tools.browser.session_path", return_value=session_file):
+        mock_pw = AsyncMock()
+        mock_pw.chromium.launch_persistent_context.return_value = mock_context
+        mock_playwright.return_value.__aenter__.return_value = mock_pw
+
+        with patch("apply_operator.tools.browser.session_path", return_value=user_data_dir):
             async with get_page_with_session("https://example.com") as page:
                 assert page is mock_page
 
-        mock_browser.new_context.assert_awaited_once_with(storage_state=str(session_file))
+        mock_pw.chromium.launch_persistent_context.assert_awaited_once_with(
+            user_data_dir=str(user_data_dir),
+            headless=False,
+            channel="chrome",
+            args=["--disable-blink-features=AutomationControlled"],
+        )
 
-    @patch("apply_operator.tools.browser._get_browser_headed")
-    async def test_creates_context_without_session(
-        self, mock_browser_headed: MagicMock, tmp_path: Path
+    @patch("apply_operator.tools.browser.async_playwright")
+    async def test_creates_user_data_directory(
+        self, mock_playwright: MagicMock, tmp_path: Path
     ) -> None:
-        session_file = tmp_path / "new-site.com.json"  # Does not exist
-
-        mock_browser = AsyncMock()
+        user_data_dir = tmp_path / "deep" / "nested" / "example.com"
         mock_context = AsyncMock()
         mock_page = AsyncMock()
-        mock_browser.new_context.return_value = mock_context
-        mock_context.new_page.return_value = mock_page
-        mock_context.storage_state.return_value = {}
-        mock_browser_headed.return_value.__aenter__.return_value = mock_browser
+        mock_context.pages = [mock_page]
 
-        with patch("apply_operator.tools.browser.session_path", return_value=session_file):
-            async with get_page_with_session("https://new-site.com") as page:
+        mock_pw = AsyncMock()
+        mock_pw.chromium.launch_persistent_context.return_value = mock_context
+        mock_playwright.return_value.__aenter__.return_value = mock_pw
+
+        with patch("apply_operator.tools.browser.session_path", return_value=user_data_dir):
+            async with get_page_with_session("https://example.com"):
+                pass
+
+        assert user_data_dir.exists()
+
+    @patch("apply_operator.tools.browser.async_playwright")
+    async def test_creates_new_page_when_context_has_none(
+        self, mock_playwright: MagicMock, tmp_path: Path
+    ) -> None:
+        user_data_dir = tmp_path / "example.com"
+        mock_page = AsyncMock()
+        mock_context = AsyncMock()
+        mock_context.pages = []  # no existing pages
+        mock_context.new_page.return_value = mock_page
+
+        mock_pw = AsyncMock()
+        mock_pw.chromium.launch_persistent_context.return_value = mock_context
+        mock_playwright.return_value.__aenter__.return_value = mock_pw
+
+        with patch("apply_operator.tools.browser.session_path", return_value=user_data_dir):
+            async with get_page_with_session("https://example.com") as page:
                 assert page is mock_page
 
-        mock_browser.new_context.assert_awaited_once_with()
+        mock_context.new_page.assert_awaited_once()
 
-    @patch("apply_operator.tools.browser._get_browser_headed")
-    async def test_saves_session_on_exit(
-        self, mock_browser_headed: MagicMock, tmp_path: Path
+    @patch("apply_operator.tools.browser.async_playwright")
+    async def test_reuses_existing_page_from_context(
+        self, mock_playwright: MagicMock, tmp_path: Path
     ) -> None:
-        session_file = tmp_path / "sessions" / "example.com.json"
-        saved_state = {"cookies": [{"name": "token", "value": "xyz"}]}
+        user_data_dir = tmp_path / "example.com"
+        mock_existing_page = AsyncMock()
+        mock_context = AsyncMock()
+        mock_context.pages = [mock_existing_page]
 
-        mock_browser = AsyncMock()
+        mock_pw = AsyncMock()
+        mock_pw.chromium.launch_persistent_context.return_value = mock_context
+        mock_playwright.return_value.__aenter__.return_value = mock_pw
+
+        with patch("apply_operator.tools.browser.session_path", return_value=user_data_dir):
+            async with get_page_with_session("https://example.com") as page:
+                assert page is mock_existing_page
+
+        mock_context.new_page.assert_not_awaited()
+
+    @patch("apply_operator.tools.browser.async_playwright")
+    async def test_closes_context_on_exit(
+        self, mock_playwright: MagicMock, tmp_path: Path
+    ) -> None:
+        user_data_dir = tmp_path / "example.com"
         mock_context = AsyncMock()
         mock_page = AsyncMock()
-        mock_browser.new_context.return_value = mock_context
-        mock_context.new_page.return_value = mock_page
-        mock_context.storage_state.return_value = saved_state
-        mock_browser_headed.return_value.__aenter__.return_value = mock_browser
+        mock_context.pages = [mock_page]
 
-        with patch("apply_operator.tools.browser.session_path", return_value=session_file):
+        mock_pw = AsyncMock()
+        mock_pw.chromium.launch_persistent_context.return_value = mock_context
+        mock_playwright.return_value.__aenter__.return_value = mock_pw
+
+        with patch("apply_operator.tools.browser.session_path", return_value=user_data_dir):
             async with get_page_with_session("https://example.com"):
                 pass
 
-        assert session_file.exists()
-        written = json.loads(session_file.read_text())
-        assert written == saved_state
-
-    @patch("apply_operator.tools.browser._get_browser_headed")
-    async def test_creates_session_directory(
-        self, mock_browser_headed: MagicMock, tmp_path: Path
-    ) -> None:
-        session_file = tmp_path / "deep" / "nested" / "example.com.json"
-
-        mock_browser = AsyncMock()
-        mock_context = AsyncMock()
-        mock_page = AsyncMock()
-        mock_browser.new_context.return_value = mock_context
-        mock_context.new_page.return_value = mock_page
-        mock_context.storage_state.return_value = {}
-        mock_browser_headed.return_value.__aenter__.return_value = mock_browser
-
-        with patch("apply_operator.tools.browser.session_path", return_value=session_file):
-            async with get_page_with_session("https://example.com"):
-                pass
-
-        assert session_file.parent.exists()
-
-    @patch("apply_operator.tools.browser._get_browser_headed")
-    async def test_closes_page_and_context_on_exit(
-        self, mock_browser_headed: MagicMock, tmp_path: Path
-    ) -> None:
-        session_file = tmp_path / "example.com.json"
-
-        mock_browser = AsyncMock()
-        mock_context = AsyncMock()
-        mock_page = AsyncMock()
-        mock_browser.new_context.return_value = mock_context
-        mock_context.new_page.return_value = mock_page
-        mock_context.storage_state.return_value = {}
-        mock_browser_headed.return_value.__aenter__.return_value = mock_browser
-
-        with patch("apply_operator.tools.browser.session_path", return_value=session_file):
-            async with get_page_with_session("https://example.com"):
-                pass
-
-        mock_page.close.assert_awaited_once()
         mock_context.close.assert_awaited_once()
 
 

--- a/tests/test_search_jobs.py
+++ b/tests/test_search_jobs.py
@@ -224,7 +224,9 @@ class TestFindNextPage:
 
         assert result is True
         mock_element.click.assert_called_once()
-        page.wait_for_load_state.assert_called_once_with("networkidle")
+        # First call: domcontentloaded (navigation), second: networkidle (wait_for_page_ready)
+        calls = page.wait_for_load_state.call_args_list
+        assert calls[0].args == ("domcontentloaded",)
 
     @pytest.mark.asyncio
     async def test_returns_false_when_no_pagination(self) -> None:


### PR DESCRIPTION
## Summary

- Implement `analyze_fit` node with LLM-based resume-to-job fit scoring (0.0–1.0), JSON parsing, score clamping, and error handling
- Fix graph routing by adding `skip_job` node — original design had `should_apply` checking unscored jobs due to premature index advancement
- Add logging framework (`@log_node` decorator, `call_llm` `purpose=` param), smart page waiting (`wait_for_page_ready`), and fix 11 stale browser tests

## Motivation

Resolves https://github.com/takeshi-su57/apply-operator/issues/13

## Changes

### Core: analyze_fit node
- `nodes/analyze_fit.py` — full implementation: builds prompt from resume + job data via `ANALYZE_FIT` template, calls LLM, parses `{"score", "reasoning"}` JSON, clamps score to 0–1, defaults to 0.0 on invalid JSON with error logged
- `graph.py` — added `skip_job` node that advances `current_job_index` and increments `total_skipped`; changed `"skip"` edge from self-loop to `skip_job → analyze_fit`
- `tests/test_analyze_fit.py` — 18 tests covering scoring, clamping, invalid JSON, out-of-bounds, routing logic

### Bug fixes found during integration testing
- `main.py` — `_print_results` crashed with `AttributeError: 'JobListing' object has no attribute 'get'`; fixed to handle Pydantic objects
- `browser.py` — added `wait_for_page_ready()` (network idle + content stability polling) to fix 0-job extraction on JS-rendered pages
- `browser.py` — removed unused `BrowserContext` import

### Logging framework
- `tools/logging_utils.py` — new `@log_node` decorator (sync + async) for node entry/exit/duration logging
- `tools/llm_provider.py` — added `purpose=` kwarg to `call_llm()` for contextual log messages
- Applied `@log_node` to all 5 nodes, `purpose=` to all `call_llm` calls
- `.claude/rules/logging.md` — new rule file for logging conventions
- `.claude/CLAUDE.md` — added logging rule reference

### Stale test fixes (11 pre-existing failures)
- `test_browser.py` — `TestSessionPath`: removed `.json` suffix (now directories); `TestGetBrowser`: updated launch args; `TestGetPageWithSession`: rewrote 5 tests for `launch_persistent_context` API (was `_get_browser_headed`)
- `test_search_jobs.py` — `TestFindNextPage`: `networkidle` → `domcontentloaded`

## How to Test

```bash
# Unit tests (all 81 should pass)
python -m pytest tests/ -v

# Lint + type check
ruff check src/ tests/
mypy src/

# Integration test (requires .env with LLM provider keys)
python -m apply_operator run --resume ./input/resume.pdf --urls ./input/urls.txt
```

## Checklist

- [x]  Self-reviewed the code
- [x]  Added/updated tests (18 new + 11 fixed)
- [x]  No new warnings or errors (ruff check + mypy clean)
- [x]  81/81 tests passing
- [x]  Tested with real pipeline run (7 jobs scored successfully)
- [x]  Updated issue doc and documentation