### PR TITLE
feat(graph): wire minimal graph end-to-end with streaming progress

### DIFF
--- a/docs/issues/008-minimal-graph-integration.md
+++ b/docs/issues/008-minimal-graph-integration.md
@@ -13,63 +13,90 @@ Wire up parse_resume, search_jobs, analyze_fit, and report_results into a workin
 - First time you see the full LangGraph lifecycle: compile, invoke, stream, observe results
 - **This is the first milestone** — after this, you have a working (if incomplete) agent
 
-## Proposed Solution
+## Implementation
 
-1. Implement stub `fill_application` (advance index + mark applied)
-2. Implement `report_results` (save JSON to `data/results.json`)
-3. Verify `graph.py` compiles: `build_graph()` runs without errors
-4. Uncomment graph invocation in `main.py` CLI
-5. Add Rich progress display using `graph.stream()`
-6. Run end-to-end with a real resume and job URLs
+### 1. `fill_application` stub (`nodes/fill_application.py`)
 
-### LangGraph concept: invoke vs stream
+The stub marks the current job as applied and advances the pipeline — no real form filling yet (deferred to issue 009). Uses `model_copy()` to immutably update the job:
 
 ```python
-# invoke() — run all nodes, return final state
-final_state = graph.invoke(initial_state)
-
-# stream() — yield state updates after each node (for progress display)
-for event in graph.stream(initial_state):
-    node_name = list(event.keys())[0]
-    print(f"Completed: {node_name}")
+jobs[idx] = jobs[idx].model_copy(update={"applied": True})
+return {
+    "jobs": jobs,
+    "current_job_index": idx + 1,
+    "total_applied": state.total_applied + 1,
+}
 ```
 
-### Common pitfalls
+### 2. Rich progress display via streaming (`main.py`)
 
-- **Infinite loop** — if `current_job_index` never advances
-- **Pydantic vs dict** — LangGraph works with dicts internally; nodes return plain dicts
-- **State merge** — if two nodes both update `jobs`, last one wins
+Replaced `graph.ainvoke()` with `graph.astream(state, stream_mode="updates")` to display real-time progress. Each node completion prints a green checkmark:
 
-### Debugging the graph
-
-```python
-graph = build_graph()
-print(graph.get_graph().draw_ascii())  # visualize node/edge structure
+```
+  ✓ parse_resume
+  ✓ search_jobs
+  ✓ analyze_fit
+  ✓ fill_application
+  ✓ report_results
 ```
 
-## Alternatives Considered
+Node outputs are accumulated into a flat dict via `.update()`. A `None` guard handles nodes that return empty results (e.g., `report_results` returns `{}`).
 
-- **Build the full pipeline with form filling first** — too risky; validate the graph structure before adding complexity
+### 3. Integration tests (`tests/test_graph.py`)
+
+12 tests covering compilation, pipeline routing, streaming, and CLI output:
+
+| Test | What it verifies |
+|------|-----------------|
+| `test_graph_compiles` | `build_graph()` returns without error |
+| `test_graph_has_expected_nodes` | All 6 nodes + `__start__`/`__end__` present |
+| `test_mixed_fit_scores` | 2 applied (>=0.6), 1 skipped (<0.6) |
+| `test_no_jobs_found` | Empty jobs list terminates without calling analyze_fit |
+| `test_all_low_fit` | All 3 jobs skipped, none applied |
+| `test_all_high_fit` | All 2 jobs applied |
+| `test_single_job_applied` | Single high-fit job marked applied |
+| `test_single_job_skipped` | Single low-fit job marked skipped |
+| `test_report_results_writes_json` | JSON output written to disk |
+| `test_streaming_yields_all_node_names` | `astream` yields events for every node |
+| `test_streaming_state_matches_ainvoke` | Accumulated stream state matches `ainvoke` result |
+| `test_prints_results_from_streamed_state` | `_print_results` renders Rich table correctly |
+
+Mocking strategy: patch node functions at the `apply_operator.graph` module level before `build_graph()` so the compiled graph uses mock functions. External I/O (LLM, browser, PDF) is never called.
+
+### Key decisions
+
+- **`stream_mode="updates"` over `"values"`**: updates mode yields `{node_name: output_dict}` which lets us both display progress and accumulate state. The `"values"` mode yields the full state but doesn't expose node names.
+- **`model_copy()` over mutation**: Pydantic objects in the jobs list are immutable by convention. The stub creates a copy with `applied=True` rather than mutating in place.
+- **`None` guard on stream accumulation**: `report_results` returns `{}` which LangGraph can serialize as `None` in stream events. Both `main.py` and tests guard against this.
+
+### What `graph.py` and `report_results.py` already had
+
+Both were already fully implemented before this issue:
+- `graph.py` — all nodes, edges, conditional routing (`should_apply`, `has_more_jobs`, `skip_job`)
+- `report_results.py` — writes `data/results.json`, logs summary counts
+
+No changes were needed in either file.
 
 ## Acceptance Criteria
 
-- [ ] `build_graph()` compiles without errors
-- [ ] `python -m apply_operator run --resume resume.pdf --urls urls.txt` executes the full pipeline
-- [ ] All jobs are analyzed and scored
-- [ ] High-fit jobs marked as "applied" (stub), low-fit jobs "skipped"
-- [ ] Results saved to `data/results.json`
-- [ ] Results table printed to console with Rich formatting
-- [ ] No infinite loops — pipeline terminates for any input
-- [ ] Integration test passes with mocked dependencies
-- [ ] `ruff check` and `mypy` pass
+- [x] `build_graph()` compiles without errors
+- [x] `python -m apply_operator run --resume resume.pdf --urls urls.txt` executes the full pipeline
+- [x] All jobs are analyzed and scored
+- [x] High-fit jobs marked as "applied" (stub), low-fit jobs "skipped"
+- [x] Results saved to `data/results.json`
+- [x] Results table printed to console with Rich formatting
+- [x] No infinite loops — pipeline terminates for any input
+- [x] Integration test passes with mocked dependencies (12 tests)
+- [x] `ruff check` and `mypy` pass (93/93 tests, 0 errors)
 
-## Files Touched
+## Files Changed
 
-- `src/apply_operator/nodes/fill_application.py` — stub implementation
-- `src/apply_operator/nodes/report_results.py` — implement
-- `src/apply_operator/main.py` — wire graph + progress display
-- `src/apply_operator/graph.py` — verify, fix if needed
-- `tests/test_graph.py` — create integration test
+| File | Change |
+|------|--------|
+| `src/apply_operator/nodes/fill_application.py` | Stub: mark job applied, increment counter, log |
+| `src/apply_operator/main.py` | Replace `ainvoke` with `astream` + Rich progress display |
+| `tests/test_graph.py` | New: 12 integration tests |
+| `docs/issues/008-minimal-graph-integration.md` | Updated with implementation details |
 
 ## Related Issues
 

--- a/src/apply_operator/main.py
+++ b/src/apply_operator/main.py
@@ -56,9 +56,25 @@ def run(
     from apply_operator.state import ApplicationState
 
     graph = build_graph()
-    state = ApplicationState(resume_path=str(resume), job_urls=job_urls)
-    result = asyncio.run(graph.ainvoke(state))
+    initial = ApplicationState(resume_path=str(resume), job_urls=job_urls)
+    result = asyncio.run(_run_graph(graph, initial))
     _print_results(result)
+
+
+async def _run_graph(
+    graph: Any,
+    initial: Any,
+) -> dict[str, Any]:
+    """Stream graph execution, printing each node as it completes."""
+    final_state: dict[str, Any] = {}
+    async for event in graph.astream(initial, stream_mode="updates"):
+        for node_name in event:
+            console.print(f"  [green]\u2713[/green] {node_name}")
+        for node_output in event.values():
+            if node_output:
+                final_state.update(node_output)
+    console.print()
+    return final_state
 
 
 @app.command()

--- a/src/apply_operator/nodes/fill_application.py
+++ b/src/apply_operator/nodes/fill_application.py
@@ -1,9 +1,12 @@
 """Node: Fill and submit a job application form."""
 
+import logging
 from typing import Any
 
 from apply_operator.state import ApplicationState
 from apply_operator.tools.logging_utils import log_node
+
+logger = logging.getLogger(__name__)
 
 
 @log_node
@@ -13,8 +16,19 @@ def fill_application(state: ApplicationState) -> dict[str, Any]:
     Navigates to the application page, identifies form fields,
     uses LLM to determine appropriate values from resume data,
     fills the form, and submits.
+
+    Currently a stub: marks the job as applied and advances the index.
+    Real browser form filling will be implemented in issue 009.
     """
-    # TODO: Implement form filling via Playwright + LLM
-    # For now, skip by advancing the index
     idx = state.current_job_index
-    return {"current_job_index": idx + 1}
+    jobs = list(state.jobs)
+    job = jobs[idx].model_copy(update={"applied": True})
+    jobs[idx] = job
+
+    logger.info("Stub applied job: %s at %s", job.title, job.company)
+
+    return {
+        "jobs": jobs,
+        "current_job_index": idx + 1,
+        "total_applied": state.total_applied + 1,
+    }

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -1,0 +1,344 @@
+"""Integration tests for the LangGraph pipeline."""
+
+import json
+from io import StringIO
+from pathlib import Path
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from apply_operator.state import ApplicationState, JobListing, ResumeData
+
+
+class TestGraphCompilation:
+    """Tests that the graph compiles and has expected structure."""
+
+    def test_graph_compiles(self) -> None:
+        from apply_operator.graph import build_graph
+
+        graph = build_graph()
+        assert graph is not None
+
+    def test_graph_has_expected_nodes(self) -> None:
+        from apply_operator.graph import build_graph
+
+        graph = build_graph()
+        node_names = set(graph.get_graph().nodes)
+        expected = {
+            "__start__",
+            "__end__",
+            "parse_resume",
+            "search_jobs",
+            "analyze_fit",
+            "skip_job",
+            "fill_application",
+            "report_results",
+        }
+        assert expected == node_names
+
+
+def _make_resume() -> ResumeData:
+    return ResumeData(
+        raw_text="Jane Smith\nPython Developer",
+        name="Jane Smith",
+        skills=["Python", "Django"],
+        experience=[
+            {
+                "title": "Backend Engineer",
+                "company": "Acme",
+                "duration": "2021-2024",
+                "description": "Built APIs",
+            }
+        ],
+        summary="Experienced backend developer.",
+    )
+
+
+def _make_jobs(count: int) -> list[JobListing]:
+    """Create jobs for testing (fit_score starts at 0)."""
+    return [
+        JobListing(
+            url=f"https://example.com/jobs/{i}",
+            title=f"Job {i}",
+            company=f"Company {i}",
+            description=f"Description for job {i}",
+        )
+        for i in range(count)
+    ]
+
+
+def _fake_parse(state: ApplicationState) -> dict[str, Any]:
+    """Mock parse_resume: return a canned resume."""
+    return {"resume": _make_resume()}
+
+
+def _fake_search(jobs: list[JobListing]):  # type: ignore[no-untyped-def]
+    """Return a factory for a mock search_jobs that returns given jobs."""
+
+    def _search(state: ApplicationState) -> dict[str, Any]:
+        return {"jobs": jobs, "current_job_index": 0}
+
+    return _search
+
+
+def _fake_analyze(scores: list[float]):  # type: ignore[no-untyped-def]
+    """Return a factory for a mock analyze_fit that assigns scores in order."""
+    call_count = 0
+
+    def _analyze(state: ApplicationState) -> dict[str, Any]:
+        nonlocal call_count
+        idx = state.current_job_index
+        if idx >= len(state.jobs):
+            return {}
+        updated_jobs = list(state.jobs)
+        updated_jobs[idx] = updated_jobs[idx].model_copy(update={"fit_score": scores[call_count]})
+        call_count += 1
+        return {"jobs": updated_jobs}
+
+    return _analyze
+
+
+def _noop_report(state: ApplicationState) -> dict[str, Any]:
+    """Mock report_results: no-op."""
+    return {}
+
+
+class TestFullPipeline:
+    """Integration tests that run the compiled graph with mocked external deps."""
+
+    def _build_mocked_graph(
+        self,
+        jobs: list[JobListing],
+        scores: list[float],
+        mock_report: bool = True,
+    ) -> Any:
+        """Build graph with mocked parse, search, analyze, and optionally report."""
+        patches = [
+            patch("apply_operator.graph.parse_resume", _fake_parse),
+            patch("apply_operator.graph.search_jobs", _fake_search(jobs)),
+            patch("apply_operator.graph.analyze_fit", _fake_analyze(scores)),
+        ]
+        if mock_report:
+            patches.append(patch("apply_operator.graph.report_results", _noop_report))
+
+        from contextlib import ExitStack
+
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            from apply_operator.graph import build_graph
+
+            return build_graph()
+
+    @pytest.mark.asyncio
+    async def test_mixed_fit_scores(self) -> None:
+        """Pipeline with a mix of high-fit and low-fit jobs."""
+        jobs = _make_jobs(3)
+        scores = [0.8, 0.3, 0.9]
+
+        graph = self._build_mocked_graph(jobs, scores)
+        result = await graph.ainvoke(
+            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+        )
+
+        assert result["total_applied"] == 2
+        assert result["total_skipped"] == 1
+        assert result["current_job_index"] == 3
+
+        applied = [j for j in result["jobs"] if j.applied]
+        skipped = [j for j in result["jobs"] if not j.applied]
+        assert len(applied) == 2
+        assert len(skipped) == 1
+
+    @pytest.mark.asyncio
+    async def test_no_jobs_found(self) -> None:
+        """Pipeline terminates cleanly when no jobs are found."""
+        graph = self._build_mocked_graph(jobs=[], scores=[])
+        result = await graph.ainvoke(
+            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+        )
+
+        assert result["total_applied"] == 0
+        assert result["total_skipped"] == 0
+
+    @pytest.mark.asyncio
+    async def test_all_low_fit(self) -> None:
+        """All jobs skipped when all have low fit scores."""
+        jobs = _make_jobs(3)
+        scores = [0.2, 0.1, 0.4]
+
+        graph = self._build_mocked_graph(jobs, scores)
+        result = await graph.ainvoke(
+            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+        )
+
+        assert result["total_applied"] == 0
+        assert result["total_skipped"] == 3
+        assert all(not j.applied for j in result["jobs"])
+
+    @pytest.mark.asyncio
+    async def test_all_high_fit(self) -> None:
+        """All jobs applied when all have high fit scores."""
+        jobs = _make_jobs(2)
+        scores = [0.85, 0.75]
+
+        graph = self._build_mocked_graph(jobs, scores)
+        result = await graph.ainvoke(
+            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+        )
+
+        assert result["total_applied"] == 2
+        assert result["total_skipped"] == 0
+        assert all(j.applied for j in result["jobs"])
+
+    @pytest.mark.asyncio
+    async def test_single_job_applied(self) -> None:
+        """Single high-fit job is applied."""
+        jobs = _make_jobs(1)
+        scores = [0.7]
+
+        graph = self._build_mocked_graph(jobs, scores)
+        result = await graph.ainvoke(
+            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+        )
+
+        assert result["total_applied"] == 1
+        assert result["total_skipped"] == 0
+        assert result["jobs"][0].applied is True
+
+    @pytest.mark.asyncio
+    async def test_single_job_skipped(self) -> None:
+        """Single low-fit job is skipped."""
+        jobs = _make_jobs(1)
+        scores = [0.3]
+
+        graph = self._build_mocked_graph(jobs, scores)
+        result = await graph.ainvoke(
+            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+        )
+
+        assert result["total_applied"] == 0
+        assert result["total_skipped"] == 1
+        assert result["jobs"][0].applied is False
+
+    @pytest.mark.asyncio
+    async def test_report_results_writes_json(self, tmp_path: Path) -> None:
+        """report_results node writes results to JSON file."""
+        jobs = _make_jobs(1)
+        scores = [0.7]
+
+        output_path = tmp_path / "results.json"
+
+        # Build graph with real report_results but redirect output path
+        graph = self._build_mocked_graph(jobs, scores, mock_report=False)
+
+        with patch(
+            "apply_operator.nodes.report_results.Path",
+        ) as mock_path_cls:
+            # Make Path("data/results.json") return our tmp path
+            mock_path_obj = mock_path_cls.return_value
+            mock_path_obj.parent.mkdir.return_value = None
+            mock_path_obj.write_text.side_effect = lambda text: output_path.write_text(text)
+
+            await graph.ainvoke(
+                ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+            )
+
+        assert output_path.exists()
+        data = json.loads(output_path.read_text())
+        assert data["total_applied"] == 1
+        assert len(data["jobs"]) == 1
+
+    @pytest.mark.asyncio
+    async def test_streaming_yields_all_node_names(self) -> None:
+        """astream with updates mode yields events for every node in the pipeline."""
+        jobs = _make_jobs(1)
+        scores = [0.7]
+
+        graph = self._build_mocked_graph(jobs, scores)
+        initial = ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+
+        node_names: list[str] = []
+        async for event in graph.astream(initial, stream_mode="updates"):
+            for name in event:
+                node_names.append(name)
+
+        # All pipeline nodes should appear (fill_application because score >= 0.6)
+        assert "parse_resume" in node_names
+        assert "search_jobs" in node_names
+        assert "analyze_fit" in node_names
+        assert "fill_application" in node_names
+        assert "report_results" in node_names
+
+    @pytest.mark.asyncio
+    async def test_streaming_state_matches_ainvoke(self) -> None:
+        """Accumulated streaming updates produce the same result as ainvoke."""
+        jobs = _make_jobs(2)
+        scores = [0.8, 0.4]
+
+        # Build two separate graphs (mocks have internal state)
+        graph1 = self._build_mocked_graph(jobs, scores)
+        graph2 = self._build_mocked_graph(jobs, [0.8, 0.4])
+
+        initial = ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+
+        # Get result via ainvoke
+        invoke_result = await graph1.ainvoke(initial)
+
+        # Get result via streaming accumulation (same as _run_graph in main.py)
+        stream_state: dict[str, Any] = {}
+        async for event in graph2.astream(initial, stream_mode="updates"):
+            for node_output in event.values():
+                if node_output:
+                    stream_state.update(node_output)
+
+        # Key fields must match
+        assert stream_state["total_applied"] == invoke_result["total_applied"]
+        assert stream_state["total_skipped"] == invoke_result["total_skipped"]
+        assert len(stream_state["jobs"]) == len(invoke_result["jobs"])
+        for s_job, i_job in zip(stream_state["jobs"], invoke_result["jobs"], strict=True):
+            assert s_job.applied == i_job.applied
+            assert s_job.fit_score == i_job.fit_score
+
+
+class TestPrintResults:
+    """Tests for the _print_results CLI helper."""
+
+    def test_prints_results_from_streamed_state(self) -> None:
+        """_print_results works with dict state from streaming (not Pydantic objects)."""
+        from apply_operator.main import _print_results
+
+        state: dict[str, Any] = {
+            "jobs": [
+                JobListing(
+                    url="https://example.com/1",
+                    title="Python Dev",
+                    company="Acme",
+                    fit_score=0.8,
+                    applied=True,
+                ),
+                JobListing(
+                    url="https://example.com/2",
+                    title="Go Dev",
+                    company="Beta",
+                    fit_score=0.3,
+                    applied=False,
+                ),
+            ],
+            "total_applied": 1,
+            "total_skipped": 1,
+        }
+
+        # Should not raise
+        from rich.console import Console
+
+        test_console = Console(file=StringIO(), width=120)
+        with patch("apply_operator.main.console", test_console):
+            _print_results(state)
+
+        output = test_console.file.getvalue()  # type: ignore[union-attr]
+        assert "Python Dev" in output
+        assert "Go Dev" in output
+        assert "Applied" in output
+        assert "Skipped" in output


### PR DESCRIPTION
## Summary

- Complete `fill_application` stub to mark jobs as `applied=True`, increment `total_applied`, and advance `current_job_index`
- Replace `graph.ainvoke()` with `graph.astream(stream_mode="updates")` in CLI for real-time progress display (green checkmarks per node)
- Add 12 integration tests covering graph compilation, all pipeline routing scenarios, streaming parity, and Rich output

## Motivation

Resolves https://github.com/takeshi-su57/apply-operator/issues/15

This is the **first milestone** — validates the full LangGraph lifecycle (compile, stream, observe results) before tackling browser form filling in issue 009. After this PR, the agent runs end-to-end: parse resume → search jobs → score fit → stub-apply or skip → save results.

## Changes

| File | Change |
|------|--------|
| `src/apply_operator/nodes/fill_application.py` | Stub: `model_copy(update={"applied": True})`, increment `total_applied`, log |
| `src/apply_operator/main.py` | `_run_graph()` streams via `astream` with `✓ node_name` progress, guards `None` outputs |
| `tests/test_graph.py` | 12 new tests (compilation, mixed/all-high/all-low/empty/single jobs, streaming, Rich output) |
| `docs/issues/008-minimal-graph-integration.md` | Updated with implementation details and checked-off acceptance criteria |

## How to Test

```bash
# Run integration tests
uv run pytest tests/test_graph.py -v

# Run full suite (93 tests)
uv run pytest -v

# Lint + type check
uv run ruff check src/ tests/
uv run mypy src/

# Real end-to-end (requires LLM API key in .env + Playwright browsers)
python -m apply_operator run --resume resume.pdf --urls urls.txt
```

## Test plan

- [x] `build_graph()` compiles with all 8 nodes
- [x] Mixed fit scores: 2 applied, 1 skipped
- [x] Empty jobs list terminates cleanly
- [x] All low-fit jobs skipped, all high-fit jobs applied
- [x] Single job applied/skipped correctly
- [x] `report_results` writes valid JSON to disk
- [x] `astream` yields events for every node
- [x] Streaming accumulated state matches `ainvoke` result
- [x] `_print_results` renders Rich table from streamed state
- [x] `ruff check` — 0 errors
- [x] `mypy` — 0 errors
- [x] Full suite — 93/93 passed
