### PR TITLE
feat(nodes): implement fill_application node with browser form automa…

### DIFF
--- a/docs/issues/009-fill-application-node.md
+++ b/docs/issues/009-fill-application-node.md
@@ -14,129 +14,79 @@ Implement the real `fill_application` node that uses Playwright to navigate to a
 - Bot detection during form submission is common — the agent must pause for user to solve CAPTCHAs
 - **This is the second milestone** — after this, the agent can actually apply to jobs
 
-## Proposed Solution
+## Implementation
 
-### LLM-guided form filling approach
+### Browser utilities added to `tools/browser.py`
 
-1. Navigate to application page
-2. Detect CAPTCHA or verification — if found, pause for user
-3. Extract form field metadata via JavaScript (`get_form_fields()`)
-4. Send fields + resume data to LLM with `MAP_FORM_FIELDS` prompt
-5. Parse LLM response (field_name → value mapping)
-6. Fill each field with Playwright (text, dropdown, file upload, checkbox)
-7. Before submit — detect CAPTCHA again, pause if needed
-8. Submit and verify
+**`FormField` TypedDict** — structured metadata for each form field:
+- `tag`, `field_type`, `name`, `label`, `required`, `selector`, `options`
 
-### CAPTCHA / bot detection
+**`get_form_fields(page) -> list[FormField]`** — JavaScript evaluation that:
+- Finds all `input`, `select`, `textarea` elements
+- Skips `hidden`, `submit`, `button` types and elements without name/id
+- Resolves labels via `label[for]`, parent `<label>`, `aria-label`, `placeholder`, `name`
+- Builds CSS selector per field (`#id` or `[name="..."]`) using `CSS.escape()`
+- Collects option value/text pairs for `<select>` elements
 
-```python
-async def detect_captcha(page: Page) -> bool:
-    """Check if a CAPTCHA or bot verification is present."""
-    captcha_selectors = [
-        'iframe[src*="recaptcha"]', 'iframe[src*="hcaptcha"]',
-        '[class*="captcha"]', '#captcha', '[data-captcha]',
-        'iframe[src*="challenge"]',
-    ]
-    for selector in captcha_selectors:
-        element = await page.query_selector(selector)
-        if element and await element.is_visible():
-            return True
-    return False
+**`detect_captcha(page) -> bool`** — checks for CAPTCHA via:
+- DOM selectors: `iframe[src*="recaptcha"]`, `iframe[src*="hcaptcha"]`, `.g-recaptcha`, `#captcha`, `[class*='captcha']`, `[data-captcha]`, `iframe[src*="challenge"]`
+- Text indicators: "verify you are human", "are you a robot", "complete the captcha", "security check", "prove you're not a robot"
 
-async def handle_captcha_if_present(page: Page) -> None:
-    """If CAPTCHA detected, pause for user to solve it."""
-    if await detect_captcha(page):
-        await wait_for_user(page, "CAPTCHA detected. Please solve it in the browser.")
-```
+**`handle_captcha_if_present(page)`** — if CAPTCHA detected, calls `wait_for_user()` then `wait_for_page_ready()`
 
-### Form field extraction (JavaScript in browser)
+### Prompts in `prompts/form_filling.py`
 
-```python
-async def get_form_fields(page: Page) -> list[dict]:
-    return await page.evaluate("""() => {
-        const fields = [];
-        document.querySelectorAll('input, select, textarea').forEach(el => {
-            const label = document.querySelector(`label[for="${el.id}"]`)?.textContent
-                || el.getAttribute('aria-label') || el.placeholder || el.name || '';
-            fields.push({
-                tag: el.tagName.toLowerCase(), type: el.type || 'text',
-                name: el.name || el.id || '', label: label.trim(),
-                required: el.required, selector: el.id ? '#' + el.id : `[name="${el.name}"]`,
-                options: el.tagName === 'SELECT'
-                    ? [...el.options].map(o => ({value: o.value, text: o.textContent})) : [],
-            });
-        });
-        return fields;
-    }""")
-```
+**`MAP_FORM_FIELDS`** — enhanced with:
+- `{job_title}`, `{company}`, `{summary}` placeholders for context-aware filling
+- Field type instructions: checkboxes → `"true"/"false"`, file → `"RESUME_FILE"` sentinel, select → exact option text
+- Uses field `name` as JSON key
+- Cover letter instruction: compose brief answer using candidate summary + job context
 
-### Multi-page form handling
+**`DETECT_FORM_PAGE_TYPE`** (new) — classifies page as `"form"`, `"confirmation"`, `"error"`, or `"other"` for post-submit verification
 
-Some applications have Next → Next → Submit flows. Loop: extract fields → fill → click next → check for CAPTCHA → repeat until submit.
+### Node implementation in `nodes/fill_application.py`
 
-### File upload (resume PDF)
+Converted from sync stub to full async node following `search_jobs` pattern:
 
-```python
-file_input = await page.query_selector('input[type="file"]')
-if file_input:
-    await file_input.set_input_files(state.resume_path)
-```
+**Helper functions:**
+- `_strip_markdown_json()` — strips markdown code fences from LLM responses
+- `_format_experience()` / `_format_education()` — format resume data for prompt
+- `_format_fields_for_prompt()` — format `FormField` list as readable text for LLM
+- `_map_fields_with_llm(fields, resume, job)` — LLM-powered field-to-value mapping
+- `_fill_field(page, field, value, resume_path)` — dispatches by field type:
+  - text/email/tel/url/textarea → `page.fill()`
+  - select → `page.select_option(label=value)`
+  - checkbox/radio → `page.check()` / `page.uncheck()`
+  - file → `page.set_input_files(resume_path)` when value is `"RESUME_FILE"`
+- `_find_and_click(page, selectors)` — tries selectors in order, clicks first visible match
+- `_verify_submission(page)` — text heuristic first, then LLM classification
 
-### Full node flow
+**Main node flow:**
+1. Open browser with `get_page_with_session(job.url)` (persistent session per domain)
+2. Navigate to application URL, wait for page ready
+3. Pre-form CAPTCHA check
+4. Multi-page form loop (max 10 pages):
+   - Extract form fields via `get_form_fields()`
+   - LLM maps resume data to field values
+   - Fill each field via `_fill_field()`
+   - Pre-submit CAPTCHA check
+   - Try "Next"/"Continue" button → continue loop
+   - Try "Submit"/"Apply" button → break
+   - Neither found → break (dead end)
+5. Verify submission via `_verify_submission()`
+6. Take evidence screenshot to `data/screenshots/`
+7. Update job state accordingly
+8. Error handling: outer try/except catches all, records in `job.error` and `state.errors`
 
-```python
-async def fill_application(state: ApplicationState) -> dict[str, Any]:
-    job = state.jobs[state.current_job_index]
-    errors = list(state.errors)
+### Test suite: `tests/test_fill_application.py`
 
-    try:
-        async with get_page_with_session(job.url) as page:
-            await page.goto(job.url, timeout=30000)
-
-            # Handle CAPTCHA before filling
-            await handle_captcha_if_present(page)
-
-            # Multi-page form loop
-            while True:
-                fields = await get_form_fields(page)
-                if not fields:
-                    break
-
-                # LLM maps resume data to form fields
-                mapping = get_field_mapping(fields, state.resume)
-                await fill_fields(page, mapping)
-
-                # Check for next button vs submit
-                next_btn = await page.query_selector('button:text("Next")')
-                if next_btn:
-                    await next_btn.click()
-                    await page.wait_for_load_state("networkidle")
-                    await handle_captcha_if_present(page)
-                    continue
-
-                # Handle CAPTCHA before submit
-                await handle_captcha_if_present(page)
-
-                submit_btn = await page.query_selector('button[type="submit"]')
-                if submit_btn:
-                    await submit_btn.click()
-                    break
-
-            job.applied = True
-            return {
-                "jobs": update_job(state.jobs, state.current_job_index, job),
-                "current_job_index": state.current_job_index + 1,
-                "total_applied": state.total_applied + 1,
-            }
-    except Exception as e:
-        job.error = str(e)
-        errors.append(f"Failed to apply to {job.title}: {e}")
-        return {
-            "jobs": update_job(state.jobs, state.current_job_index, job),
-            "current_job_index": state.current_job_index + 1,
-            "errors": errors,
-        }
-```
+26 tests across 7 test classes:
+- `TestStripMarkdownJson` — code fence stripping
+- `TestMapFieldsWithLlm` — JSON parsing, markdown handling, invalid responses
+- `TestFillField` — text, dropdown, checkbox, file upload, error handling
+- `TestFindAndClick` — visible match, no match, hidden elements
+- `TestVerifySubmission` — heuristic detection, LLM detection, edge cases
+- `TestFillApplication` — single page, multi-page, CAPTCHA, no fields, exceptions, file upload
 
 ## Alternatives Considered
 
@@ -146,22 +96,23 @@ async def fill_application(state: ApplicationState) -> dict[str, Any]:
 
 ## Acceptance Criteria
 
-- [ ] Node navigates to application page, fills form fields, and submits
-- [ ] CAPTCHA/bot detection pauses automation and prompts user
-- [ ] User intervention resumes correctly after CAPTCHA is solved
-- [ ] Works with at least one real job application form
-- [ ] Text inputs, dropdowns, and file uploads handled
-- [ ] Multi-page forms detected and handled
-- [ ] Errors don't crash the pipeline — recorded in `job.error` and `state.errors`
-- [ ] Tests pass with mocked Playwright page and LLM
-- [ ] `ruff check` and `mypy` pass
+- [x] Node navigates to application page, fills form fields, and submits
+- [x] CAPTCHA/bot detection pauses automation and prompts user
+- [x] User intervention resumes correctly after CAPTCHA is solved
+- [ ] Works with at least one real job application form (requires manual E2E test)
+- [x] Text inputs, dropdowns, and file uploads handled
+- [x] Multi-page forms detected and handled
+- [x] Errors don't crash the pipeline — recorded in `job.error` and `state.errors`
+- [x] Tests pass with mocked Playwright page and LLM (26 tests)
+- [x] `ruff check` and `mypy` pass
 
 ## Files Touched
 
-- `src/apply_operator/nodes/fill_application.py` — full implementation
-- `src/apply_operator/tools/browser.py` — add `get_form_fields()`, `detect_captcha()`, `handle_captcha_if_present()`
-- `src/apply_operator/prompts/form_filling.py` — refine `MAP_FORM_FIELDS`
-- `tests/test_fill_application.py` — create
+- `src/apply_operator/nodes/fill_application.py` — full async implementation (363 lines)
+- `src/apply_operator/tools/browser.py` — added `FormField`, `get_form_fields()`, `detect_captcha()`, `handle_captcha_if_present()` (366 lines total)
+- `src/apply_operator/prompts/form_filling.py` — enhanced `MAP_FORM_FIELDS`, added `DETECT_FORM_PAGE_TYPE`
+- `tests/test_fill_application.py` — 26 tests across 7 classes (692 lines)
+- `tests/test_graph.py` — updated mock to use sync `_fake_fill` for graph compatibility
 
 ## Related Issues
 

--- a/src/apply_operator/nodes/fill_application.py
+++ b/src/apply_operator/nodes/fill_application.py
@@ -1,34 +1,362 @@
 """Node: Fill and submit a job application form."""
 
+import json
 import logging
+import re
 from typing import Any
 
-from apply_operator.state import ApplicationState
+from playwright.async_api import Page
+
+from apply_operator.config import get_settings
+from apply_operator.prompts.form_filling import DETECT_FORM_PAGE_TYPE, MAP_FORM_FIELDS
+from apply_operator.state import ApplicationState, JobListing, ResumeData
+from apply_operator.tools.browser import (
+    FormField,
+    get_form_fields,
+    get_page_text,
+    get_page_with_session,
+    handle_captcha_if_present,
+    take_screenshot,
+    wait_for_page_ready,
+)
+from apply_operator.tools.llm_provider import call_llm
 from apply_operator.tools.logging_utils import log_node
 
 logger = logging.getLogger(__name__)
 
+_SUBMIT_SELECTORS = [
+    'button[type="submit"]',
+    'input[type="submit"]',
+    'button:text("Submit")',
+    'button:text("Apply")',
+    'button:text("Send")',
+    'button:text("Submit Application")',
+]
+
+_NEXT_PAGE_SELECTORS = [
+    'button:text("Next")',
+    'button:text("Continue")',
+    'a:text("Next")',
+    'button:text("next")',
+    'button:text("continue")',
+]
+
+_MAX_FORM_PAGES = 10
+
+
+def _strip_markdown_json(text: str) -> str:
+    """Strip markdown code fences from LLM JSON responses."""
+    match = re.search(r"```(?:json)?\s*\n?(.*?)\n?\s*```", text, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    return text.strip()
+
+
+def _format_experience(experience: list[dict[str, Any]]) -> str:
+    """Format experience list into a readable string for the prompt."""
+    if not experience:
+        return "No experience listed"
+    parts = []
+    for exp in experience:
+        title = exp.get("title", "Unknown")
+        company = exp.get("company", "Unknown")
+        duration = exp.get("duration", "")
+        desc = exp.get("description", "")
+        entry = f"{title} at {company}"
+        if duration:
+            entry += f" ({duration})"
+        if desc:
+            entry += f" — {desc}"
+        parts.append(entry)
+    return "; ".join(parts)
+
+
+def _format_education(education: list[dict[str, Any]]) -> str:
+    """Format education list into a readable string for the prompt."""
+    if not education:
+        return "No education listed"
+    parts = []
+    for edu in education:
+        degree = edu.get("degree", "Unknown")
+        institution = edu.get("institution", "Unknown")
+        year = edu.get("year", "")
+        entry = f"{degree} from {institution}"
+        if year:
+            entry += f" ({year})"
+        parts.append(entry)
+    return "; ".join(parts)
+
+
+def _format_fields_for_prompt(fields: list[FormField]) -> str:
+    """Format form fields into a readable list for the LLM prompt."""
+    lines = []
+    for f in fields:
+        line = f'- name={f["name"]}, label="{f["label"]}", type={f["field_type"]}'
+        if f["required"]:
+            line += ", required"
+        if f["options"]:
+            opts = ", ".join(o["text"] for o in f["options"])
+            line += f", options=[{opts}]"
+        lines.append(line)
+    return "\n".join(lines)
+
+
+def _map_fields_with_llm(
+    fields: list[FormField], resume: ResumeData, job: JobListing
+) -> dict[str, str]:
+    """Use LLM to map resume data to form field values.
+
+    Args:
+        fields: Extracted form fields from the page.
+        resume: Parsed resume data.
+        job: Current job listing being applied to.
+
+    Returns:
+        Mapping of field name to value to fill in.
+    """
+    prompt = MAP_FORM_FIELDS.format(
+        job_title=job.title or "Unknown Position",
+        company=job.company or "Unknown Company",
+        form_fields=_format_fields_for_prompt(fields),
+        name=resume.name,
+        email=resume.email,
+        phone=resume.phone,
+        summary=resume.summary or "No summary available",
+        skills=", ".join(resume.skills) if resume.skills else "None listed",
+        experience=_format_experience(resume.experience),
+        education=_format_education(resume.education),
+    )
+
+    try:
+        response = call_llm(prompt, purpose=f"map_form_fields for {job.title} at {job.company}")
+        cleaned = _strip_markdown_json(response)
+        mapping = json.loads(cleaned)
+        if not isinstance(mapping, dict):
+            logger.warning("LLM returned non-dict for field mapping: %s", type(mapping))
+            return {}
+        return {str(k): str(v) for k, v in mapping.items()}
+    except (json.JSONDecodeError, ValueError, TypeError) as e:
+        logger.warning("Failed to parse LLM field mapping: %s", e)
+        return {}
+
+
+async def _fill_field(page: Page, field: FormField, value: str, resume_path: str) -> None:
+    """Fill a single form field with the given value.
+
+    Args:
+        page: Playwright page.
+        field: Form field metadata.
+        value: Value to fill in.
+        resume_path: Path to resume PDF for file upload fields.
+    """
+    selector = field["selector"]
+    field_type = field["field_type"]
+
+    try:
+        if field_type == "file":
+            if value == "RESUME_FILE" and resume_path:
+                file_input = await page.query_selector(selector)
+                if file_input:
+                    await file_input.set_input_files(resume_path)
+                    logger.debug("Uploaded resume to %s", field["name"])
+            return
+
+        if field_type == "select":
+            await page.select_option(selector, label=value)
+            logger.debug("Selected '%s' for %s", value, field["name"])
+            return
+
+        if field_type in ("checkbox", "radio"):
+            if value.lower() in ("true", "yes", "on", "1"):
+                await page.check(selector)
+            else:
+                await page.uncheck(selector)
+            logger.debug("Set %s to %s for %s", field_type, value, field["name"])
+            return
+
+        # text, email, tel, url, textarea
+        await page.fill(selector, value)
+        logger.debug("Filled %s with %d chars", field["name"], len(value))
+    except Exception as e:
+        logger.warning("Failed to fill field %s: %s", field["name"], e)
+
+
+async def _find_and_click(page: Page, selectors: list[str]) -> bool:
+    """Try to find and click the first visible element matching any selector.
+
+    Args:
+        page: Playwright page.
+        selectors: CSS/text selectors to try in order.
+
+    Returns:
+        True if an element was found and clicked.
+    """
+    for selector in selectors:
+        try:
+            element = await page.query_selector(selector)
+            if element and await element.is_visible():
+                await element.click()
+                await page.wait_for_load_state("domcontentloaded")
+                return True
+        except Exception:
+            continue
+    return False
+
+
+async def _verify_submission(page: Page) -> bool:
+    """Check if the current page indicates a successful form submission.
+
+    Uses LLM to classify the page, with a text-based heuristic fallback.
+
+    Args:
+        page: Playwright page after form submission.
+
+    Returns:
+        True if the page appears to be a confirmation page.
+    """
+    text = await get_page_text(page)
+    if not text.strip():
+        return False
+
+    # Heuristic fallback keywords
+    confirmation_keywords = [
+        "thank you",
+        "application received",
+        "successfully submitted",
+        "application submitted",
+        "we have received",
+        "confirmation",
+    ]
+    text_lower = text.lower()[:2000]
+    if any(kw in text_lower for kw in confirmation_keywords):
+        logger.info("Submission confirmed via text heuristic")
+        return True
+
+    # LLM classification
+    try:
+        prompt = DETECT_FORM_PAGE_TYPE.format(page_text=text[:2000])
+        response = call_llm(prompt, purpose="verify_submission page type")
+        cleaned = _strip_markdown_json(response)
+        data = json.loads(cleaned)
+        page_type = str(data.get("page_type", "other"))
+        logger.info("LLM classified post-submit page as: %s", page_type)
+        return page_type == "confirmation"
+    except (json.JSONDecodeError, ValueError, TypeError) as e:
+        logger.warning("Failed to parse submission verification: %s", e)
+        return False
+
 
 @log_node
-def fill_application(state: ApplicationState) -> dict[str, Any]:
+async def fill_application(state: ApplicationState) -> dict[str, Any]:
     """Use Playwright + LLM to fill out the job application form.
 
     Navigates to the application page, identifies form fields,
     uses LLM to determine appropriate values from resume data,
-    fills the form, and submits.
-
-    Currently a stub: marks the job as applied and advances the index.
-    Real browser form filling will be implemented in issue 009.
+    fills the form, handles CAPTCHAs, and submits.
     """
     idx = state.current_job_index
     jobs = list(state.jobs)
-    job = jobs[idx].model_copy(update={"applied": True})
-    jobs[idx] = job
+    job = jobs[idx]
+    errors = list(state.errors)
 
-    logger.info("Stub applied job: %s at %s", job.title, job.company)
+    try:
+        async with get_page_with_session(job.url) as page:
+            settings = get_settings()
+            logger.info("Navigating to application page: %s", job.url)
+            await page.goto(job.url, timeout=settings.browser_timeout)
+            await wait_for_page_ready(page)
 
-    return {
-        "jobs": jobs,
-        "current_job_index": idx + 1,
-        "total_applied": state.total_applied + 1,
-    }
+            # Pre-form CAPTCHA check
+            await handle_captcha_if_present(page)
+
+            form_filled = False
+
+            for page_num in range(_MAX_FORM_PAGES):
+                fields = await get_form_fields(page)
+                if not fields:
+                    logger.info("No form fields found on page %d", page_num + 1)
+                    break
+
+                logger.info("Page %d: found %d form fields", page_num + 1, len(fields))
+
+                # LLM maps resume data to form fields
+                mapping = _map_fields_with_llm(fields, state.resume, job)
+                if not mapping:
+                    logger.warning("LLM returned empty field mapping on page %d", page_num + 1)
+
+                # Fill each mapped field
+                filled_count = 0
+                for field in fields:
+                    value = mapping.get(field["name"], "")
+                    if not value:
+                        continue
+                    await _fill_field(page, field, value, state.resume_path)
+                    filled_count += 1
+
+                logger.info(
+                    "Filled %d/%d fields on page %d",
+                    filled_count,
+                    len(fields),
+                    page_num + 1,
+                )
+                form_filled = True
+
+                # Pre-submit CAPTCHA check
+                await handle_captcha_if_present(page)
+
+                # Try next-page button first
+                if await _find_and_click(page, _NEXT_PAGE_SELECTORS):
+                    logger.info("Clicked next page button, advancing to page %d", page_num + 2)
+                    await wait_for_page_ready(page)
+                    continue
+
+                # Try submit button
+                if await _find_and_click(page, _SUBMIT_SELECTORS):
+                    logger.info("Clicked submit button")
+                    break
+
+                # Neither found — dead end
+                logger.warning("No next/submit button found on page %d", page_num + 1)
+                break
+
+            await wait_for_page_ready(page)
+
+            # Verify submission
+            success = form_filled and await _verify_submission(page)
+
+            # Take evidence screenshot
+            try:
+                await take_screenshot(page, f"application_{job.company}_{idx}")
+            except Exception:
+                logger.debug("Failed to take screenshot", exc_info=True)
+
+        if success:
+            logger.info("Successfully applied to %s at %s", job.title, job.company)
+            jobs[idx] = job.model_copy(update={"applied": True})
+            return {
+                "jobs": jobs,
+                "current_job_index": idx + 1,
+                "total_applied": state.total_applied + 1,
+            }
+        else:
+            msg = f"Submission not confirmed for {job.title} at {job.company}"
+            logger.warning(msg)
+            jobs[idx] = job.model_copy(update={"error": msg})
+            errors.append(msg)
+            return {
+                "jobs": jobs,
+                "current_job_index": idx + 1,
+                "total_skipped": state.total_skipped + 1,
+                "errors": errors,
+            }
+
+    except Exception as e:
+        msg = f"Failed to apply to {job.title} at {job.company}: {e}"
+        logger.error(msg)
+        jobs[idx] = job.model_copy(update={"error": str(e)})
+        errors.append(msg)
+        return {
+            "jobs": jobs,
+            "current_job_index": idx + 1,
+            "errors": errors,
+        }

--- a/src/apply_operator/prompts/form_filling.py
+++ b/src/apply_operator/prompts/form_filling.py
@@ -1,23 +1,48 @@
 """Prompts for application form field mapping."""
 
 MAP_FORM_FIELDS = """You are filling out a job application form.
+Position: {job_title} at {company}.
 Given the form fields and candidate data, determine the best value for each field.
 
-## Form Fields (label: field_type)
+## Form Fields
+Each field has: name, label, field_type, required, and options (for dropdowns).
 {form_fields}
 
 ## Candidate Data
 Name: {name}
 Email: {email}
 Phone: {phone}
+Summary: {summary}
 Skills: {skills}
 Experience: {experience}
 Education: {education}
 
 ## Instructions
-For each form field, return the appropriate value from the candidate data.
-If a field asks for information not available in the candidate data, return an empty string.
-For dropdown/select fields, choose the closest matching option.
+Return a JSON object mapping each field's **name** attribute to the value to fill in.
 
-Return a JSON object mapping field labels to values.
+Rules:
+- For text/email/tel/url/textarea fields: return the appropriate string value.
+- For select/dropdown fields: return the **exact option text** from the available options list.
+- For checkbox/radio fields: return "true" or "false".
+- For file upload fields: return "RESUME_FILE".
+- If a field asks for a cover letter or "why do you want to work here", compose a brief \
+2-3 sentence answer using the candidate's summary and the job context.
+- If a field asks for information not available in the candidate data, return an empty string.
+- Do NOT invent information that is not in the candidate data.
+
 Return ONLY valid JSON, no other text."""
+
+DETECT_FORM_PAGE_TYPE = """Analyze the following page text and determine what type of page it is.
+
+## Page Text
+{page_text}
+
+## Instructions
+Classify this page as one of:
+- "form": The page contains an application form with fillable fields.
+- "confirmation": The page confirms a successful submission \
+(e.g., "thank you", "application received").
+- "error": The page shows an error or failure message.
+- "other": The page does not fit any of the above categories.
+
+Return ONLY valid JSON in this format: {{"page_type": "<type>"}}"""

--- a/src/apply_operator/tools/browser.py
+++ b/src/apply_operator/tools/browser.py
@@ -30,6 +30,18 @@ class LinkInfo(TypedDict):
     text: str
 
 
+class FormField(TypedDict):
+    """Typed dict for form field metadata extracted from a page."""
+
+    tag: str  # "input", "select", "textarea"
+    field_type: str  # "text", "email", "tel", "select", "textarea", "file", "checkbox", "radio"
+    name: str  # name or id attribute
+    label: str  # resolved label text
+    required: bool
+    selector: str  # CSS selector to target this field
+    options: list[dict[str, str]]  # for select: [{value, text}]
+
+
 def session_path(url: str) -> Path:
     """Get session file path for a URL's domain.
 
@@ -217,3 +229,137 @@ async def take_screenshot(page: Page, name: str) -> Path:
     await page.screenshot(path=str(path))
     logger.info("Screenshot saved: %s", path)
     return path
+
+
+_CAPTCHA_SELECTORS = [
+    'iframe[src*="recaptcha"]',
+    'iframe[src*="hcaptcha"]',
+    ".g-recaptcha",
+    "#captcha",
+    "[class*='captcha']",
+    "[data-captcha]",
+    'iframe[src*="challenge"]',
+]
+
+_CAPTCHA_TEXT_INDICATORS = [
+    "verify you are human",
+    "are you a robot",
+    "complete the captcha",
+    "security check",
+    "prove you're not a robot",
+]
+
+
+async def detect_captcha(page: Page) -> bool:
+    """Check if a CAPTCHA or bot verification is present on the page.
+
+    Args:
+        page: Playwright page to check.
+
+    Returns:
+        True if CAPTCHA or bot verification is detected.
+    """
+    for selector in _CAPTCHA_SELECTORS:
+        try:
+            element = await page.query_selector(selector)
+            if element and await element.is_visible():
+                logger.info("CAPTCHA detected via selector: %s", selector)
+                return True
+        except Exception:
+            continue
+
+    try:
+        text = await get_page_text(page)
+        text_lower = text.lower()[:2000]
+        for indicator in _CAPTCHA_TEXT_INDICATORS:
+            if indicator in text_lower:
+                logger.info("CAPTCHA detected via text indicator: %s", indicator)
+                return True
+    except Exception:
+        pass
+
+    return False
+
+
+async def handle_captcha_if_present(page: Page) -> None:
+    """If CAPTCHA is detected, pause for the user to solve it.
+
+    Args:
+        page: Playwright page to check and wait on.
+    """
+    if await detect_captcha(page):
+        await wait_for_user(page, "CAPTCHA detected. Please solve it in the browser.")
+        await wait_for_page_ready(page)
+
+
+async def get_form_fields(page: Page) -> list[FormField]:
+    """Extract form field metadata from the page via JavaScript.
+
+    Finds all input, select, and textarea elements, resolves their labels,
+    and returns structured metadata for LLM-guided form filling.
+
+    Args:
+        page: Playwright page to extract fields from.
+
+    Returns:
+        List of FormField dicts describing each fillable field.
+    """
+    try:
+        fields: list[FormField] = await page.evaluate(
+            """() => {
+            const fields = [];
+            const elements = document.querySelectorAll('input, select, textarea');
+            for (const el of elements) {
+                const type = (el.type || 'text').toLowerCase();
+                if (type === 'hidden' || type === 'submit' || type === 'button') continue;
+
+                const id = el.id || '';
+                const name = el.name || id || '';
+                if (!name && !id) continue;
+
+                // Resolve label
+                let label = '';
+                if (id) {
+                    const labelEl = document.querySelector(`label[for="${id}"]`);
+                    if (labelEl) label = labelEl.textContent.trim();
+                }
+                if (!label) {
+                    const parentLabel = el.closest('label');
+                    if (parentLabel) label = parentLabel.textContent.trim();
+                }
+                if (!label) label = el.getAttribute('aria-label') || '';
+                if (!label) label = el.placeholder || '';
+                if (!label) label = name;
+
+                // Build selector
+                const selector = id ? '#' + CSS.escape(id) : `[name="${CSS.escape(name)}"]`;
+
+                // Collect options for select elements
+                const options = [];
+                if (el.tagName === 'SELECT') {
+                    for (const opt of el.options) {
+                        if (opt.value) {
+                            options.push({value: opt.value, text: opt.textContent.trim()});
+                        }
+                    }
+                }
+
+                fields.push({
+                    tag: el.tagName.toLowerCase(),
+                    field_type: el.tagName === 'SELECT' ? 'select'
+                        : el.tagName === 'TEXTAREA' ? 'textarea' : type,
+                    name: name,
+                    label: label,
+                    required: el.required || false,
+                    selector: selector,
+                    options: options,
+                });
+            }
+            return fields;
+        }"""
+        )
+        logger.debug("Extracted %d form fields", len(fields))
+        return fields
+    except Exception:
+        logger.warning("Failed to extract form fields", exc_info=True)
+        return []

--- a/tests/test_fill_application.py
+++ b/tests/test_fill_application.py
@@ -1,0 +1,691 @@
+"""Tests for the fill_application node."""
+
+import json
+from contextlib import asynccontextmanager
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from apply_operator.nodes.fill_application import (
+    _fill_field,
+    _find_and_click,
+    _map_fields_with_llm,
+    _strip_markdown_json,
+    _verify_submission,
+    fill_application,
+)
+from apply_operator.state import ApplicationState, JobListing, ResumeData
+from apply_operator.tools.browser import FormField
+
+
+def _make_state(**kwargs: Any) -> ApplicationState:
+    """Create an ApplicationState with sensible defaults for fill_application tests."""
+    defaults: dict[str, Any] = {
+        "resume_path": "/tmp/resume.pdf",
+        "job_urls": ["https://example.com/jobs"],
+        "resume": ResumeData(
+            raw_text="John Doe\njohn@example.com\nSoftware Engineer",
+            name="John Doe",
+            email="john@example.com",
+            phone="555-0100",
+            skills=["Python", "TypeScript"],
+            experience=[
+                {
+                    "title": "Senior Engineer",
+                    "company": "Acme Corp",
+                    "duration": "2020-2024",
+                    "description": "Led backend development",
+                }
+            ],
+            education=[{"degree": "BS Computer Science", "institution": "MIT", "year": "2020"}],
+            summary="Experienced software engineer.",
+        ),
+        "jobs": [
+            JobListing(
+                url="https://example.com/apply/1",
+                title="Python Developer",
+                company="TechCo",
+                description="Looking for a Python developer.",
+                fit_score=0.8,
+            ),
+        ],
+        "current_job_index": 0,
+    }
+    defaults.update(kwargs)
+    return ApplicationState(**defaults)
+
+
+def _mock_page(url: str = "https://example.com/apply/1") -> AsyncMock:
+    """Create a mock Playwright page with standard methods."""
+    page = AsyncMock()
+    page.url = url
+    page.goto = AsyncMock()
+    page.fill = AsyncMock()
+    page.select_option = AsyncMock()
+    page.check = AsyncMock()
+    page.uncheck = AsyncMock()
+    page.query_selector = AsyncMock(return_value=None)
+    page.wait_for_load_state = AsyncMock()
+    page.evaluate = AsyncMock(return_value=[])
+    page.screenshot = AsyncMock()
+    return page
+
+
+@asynccontextmanager
+async def _fake_session(page: AsyncMock):  # type: ignore[no-untyped-def]
+    """Fake get_page_with_session context manager."""
+    yield page
+
+
+def _text_field(name: str = "full_name", label: str = "Full Name") -> FormField:
+    """Create a sample text FormField."""
+    return FormField(
+        tag="input",
+        field_type="text",
+        name=name,
+        label=label,
+        required=True,
+        selector=f'[name="{name}"]',
+        options=[],
+    )
+
+
+def _select_field(
+    name: str = "country",
+    label: str = "Country",
+    options: list[dict[str, str]] | None = None,
+) -> FormField:
+    """Create a sample select FormField."""
+    if options is None:
+        options = [
+            {"value": "us", "text": "United States"},
+            {"value": "uk", "text": "United Kingdom"},
+        ]
+    return FormField(
+        tag="select",
+        field_type="select",
+        name=name,
+        label=label,
+        required=False,
+        selector=f'[name="{name}"]',
+        options=options,
+    )
+
+
+def _file_field(name: str = "resume") -> FormField:
+    """Create a sample file upload FormField."""
+    return FormField(
+        tag="input",
+        field_type="file",
+        name=name,
+        label="Upload Resume",
+        required=False,
+        selector=f'[name="{name}"]',
+        options=[],
+    )
+
+
+def _checkbox_field(name: str = "agree_terms") -> FormField:
+    """Create a sample checkbox FormField."""
+    return FormField(
+        tag="input",
+        field_type="checkbox",
+        name=name,
+        label="I agree to the terms",
+        required=True,
+        selector=f'[name="{name}"]',
+        options=[],
+    )
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _strip_markdown_json
+# ---------------------------------------------------------------------------
+
+
+class TestStripMarkdownJson:
+    def test_strips_code_fences(self) -> None:
+        text = '```json\n{"key": "value"}\n```'
+        assert _strip_markdown_json(text) == '{"key": "value"}'
+
+    def test_returns_plain_json(self) -> None:
+        text = '{"key": "value"}'
+        assert _strip_markdown_json(text) == '{"key": "value"}'
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _map_fields_with_llm
+# ---------------------------------------------------------------------------
+
+
+class TestMapFieldsWithLlm:
+    def test_parses_valid_json_mapping(self) -> None:
+        fields = [_text_field("name", "Full Name"), _text_field("email", "Email")]
+        resume = ResumeData(name="John Doe", email="john@example.com")
+        job = JobListing(url="https://example.com/apply", title="Dev", company="Co")
+
+        llm_response = json.dumps({"name": "John Doe", "email": "john@example.com"})
+        with patch(
+            "apply_operator.nodes.fill_application.call_llm",
+            return_value=llm_response,
+        ):
+            result = _map_fields_with_llm(fields, resume, job)
+
+        assert result == {"name": "John Doe", "email": "john@example.com"}
+
+    def test_handles_markdown_wrapped_json(self) -> None:
+        fields = [_text_field()]
+        resume = ResumeData(name="John")
+        job = JobListing(url="https://example.com/apply", title="Dev", company="Co")
+
+        wrapped = '```json\n{"full_name": "John"}\n```'
+        with patch(
+            "apply_operator.nodes.fill_application.call_llm",
+            return_value=wrapped,
+        ):
+            result = _map_fields_with_llm(fields, resume, job)
+
+        assert result == {"full_name": "John"}
+
+    def test_returns_empty_on_invalid_json(self) -> None:
+        fields = [_text_field()]
+        resume = ResumeData(name="John")
+        job = JobListing(url="https://example.com/apply", title="Dev", company="Co")
+
+        with patch(
+            "apply_operator.nodes.fill_application.call_llm",
+            return_value="not valid json {{{",
+        ):
+            result = _map_fields_with_llm(fields, resume, job)
+
+        assert result == {}
+
+    def test_returns_empty_on_non_dict_response(self) -> None:
+        fields = [_text_field()]
+        resume = ResumeData(name="John")
+        job = JobListing(url="https://example.com/apply", title="Dev", company="Co")
+
+        with patch(
+            "apply_operator.nodes.fill_application.call_llm",
+            return_value='["not", "a", "dict"]',
+        ):
+            result = _map_fields_with_llm(fields, resume, job)
+
+        assert result == {}
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _fill_field
+# ---------------------------------------------------------------------------
+
+
+class TestFillField:
+    @pytest.mark.asyncio
+    async def test_fills_text_input(self) -> None:
+        page = _mock_page()
+        field = _text_field("name", "Full Name")
+        await _fill_field(page, field, "John Doe", "/tmp/resume.pdf")
+        page.fill.assert_called_once_with('[name="name"]', "John Doe")
+
+    @pytest.mark.asyncio
+    async def test_selects_dropdown_option(self) -> None:
+        page = _mock_page()
+        field = _select_field()
+        await _fill_field(page, field, "United States", "/tmp/resume.pdf")
+        page.select_option.assert_called_once_with('[name="country"]', label="United States")
+
+    @pytest.mark.asyncio
+    async def test_checks_checkbox_when_true(self) -> None:
+        page = _mock_page()
+        field = _checkbox_field()
+        await _fill_field(page, field, "true", "/tmp/resume.pdf")
+        page.check.assert_called_once_with('[name="agree_terms"]')
+
+    @pytest.mark.asyncio
+    async def test_unchecks_checkbox_when_false(self) -> None:
+        page = _mock_page()
+        field = _checkbox_field()
+        await _fill_field(page, field, "false", "/tmp/resume.pdf")
+        page.uncheck.assert_called_once_with('[name="agree_terms"]')
+
+    @pytest.mark.asyncio
+    async def test_uploads_resume_file(self) -> None:
+        page = _mock_page()
+        file_input = AsyncMock()
+        page.query_selector = AsyncMock(return_value=file_input)
+        field = _file_field()
+        await _fill_field(page, field, "RESUME_FILE", "/tmp/resume.pdf")
+        file_input.set_input_files.assert_called_once_with("/tmp/resume.pdf")
+
+    @pytest.mark.asyncio
+    async def test_skips_file_upload_without_resume_path(self) -> None:
+        page = _mock_page()
+        field = _file_field()
+        await _fill_field(page, field, "RESUME_FILE", "")
+        page.query_selector.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_handles_fill_error_gracefully(self) -> None:
+        page = _mock_page()
+        page.fill = AsyncMock(side_effect=Exception("Element not found"))
+        field = _text_field()
+        # Should not raise
+        await _fill_field(page, field, "value", "/tmp/resume.pdf")
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _find_and_click
+# ---------------------------------------------------------------------------
+
+
+class TestFindAndClick:
+    @pytest.mark.asyncio
+    async def test_clicks_first_visible_match(self) -> None:
+        mock_element = AsyncMock()
+        mock_element.is_visible = AsyncMock(return_value=True)
+
+        page = _mock_page()
+        page.query_selector = AsyncMock(return_value=mock_element)
+
+        result = await _find_and_click(page, ['button[type="submit"]'])
+
+        assert result is True
+        mock_element.click.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_returns_false_when_no_match(self) -> None:
+        page = _mock_page()
+        page.query_selector = AsyncMock(return_value=None)
+
+        result = await _find_and_click(page, ['button[type="submit"]'])
+
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_skips_hidden_elements(self) -> None:
+        mock_element = AsyncMock()
+        mock_element.is_visible = AsyncMock(return_value=False)
+
+        page = _mock_page()
+        page.query_selector = AsyncMock(return_value=mock_element)
+
+        result = await _find_and_click(page, ['button[type="submit"]'])
+
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: _verify_submission
+# ---------------------------------------------------------------------------
+
+
+class TestVerifySubmission:
+    @pytest.mark.asyncio
+    async def test_detects_confirmation_via_heuristic(self) -> None:
+        page = _mock_page()
+        with patch(
+            "apply_operator.nodes.fill_application.get_page_text",
+            return_value="Thank you for your application! We have received your submission.",
+        ):
+            result = await _verify_submission(page)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_detects_confirmation_via_llm(self) -> None:
+        page = _mock_page()
+        with (
+            patch(
+                "apply_operator.nodes.fill_application.get_page_text",
+                return_value="Your profile has been saved. Our team will review shortly.",
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.call_llm",
+                return_value='{"page_type": "confirmation"}',
+            ),
+        ):
+            result = await _verify_submission(page)
+        assert result is True
+
+    @pytest.mark.asyncio
+    async def test_returns_false_for_non_confirmation(self) -> None:
+        page = _mock_page()
+        with (
+            patch(
+                "apply_operator.nodes.fill_application.get_page_text",
+                return_value="Please fill out the following form.",
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.call_llm",
+                return_value='{"page_type": "form"}',
+            ),
+        ):
+            result = await _verify_submission(page)
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_returns_false_for_empty_page(self) -> None:
+        page = _mock_page()
+        with patch(
+            "apply_operator.nodes.fill_application.get_page_text",
+            return_value="",
+        ):
+            result = await _verify_submission(page)
+        assert result is False
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: fill_application node
+# ---------------------------------------------------------------------------
+
+
+SAMPLE_FORM_FIELDS: list[FormField] = [
+    _text_field("name", "Full Name"),
+    _text_field("email", "Email Address"),
+    _file_field("resume"),
+]
+
+SAMPLE_LLM_MAPPING = json.dumps(
+    {
+        "name": "John Doe",
+        "email": "john@example.com",
+        "resume": "RESUME_FILE",
+    }
+)
+
+
+class TestFillApplication:
+    @pytest.mark.asyncio
+    async def test_successful_single_page_application(self) -> None:
+        state = _make_state()
+        page = _mock_page()
+
+        # Submit button exists
+        submit_btn = AsyncMock()
+        submit_btn.is_visible = AsyncMock(return_value=True)
+
+        call_count = 0
+
+        async def _query_selector(selector: str) -> AsyncMock | None:
+            nonlocal call_count
+            # For file upload query
+            if selector.startswith('[name="resume"]'):
+                file_input = AsyncMock()
+                return file_input
+            # For next-page buttons: return None (no next page)
+            next_kws = ("Next", "Continue", "next", "continue")
+            if any(kw in selector for kw in next_kws):
+                return None
+            # For submit button
+            submit_kws = ("Submit", "Apply", "Send")
+            if "submit" in selector.lower() or any(kw in selector for kw in submit_kws):
+                nonlocal call_count
+                call_count += 1
+                if call_count == 1:
+                    return submit_btn
+                return None
+            return None
+
+        page.query_selector = _query_selector
+
+        with (
+            patch(
+                "apply_operator.nodes.fill_application.get_page_with_session",
+                side_effect=lambda url: _fake_session(page),
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.get_form_fields",
+                return_value=SAMPLE_FORM_FIELDS,
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.call_llm",
+                side_effect=[
+                    SAMPLE_LLM_MAPPING,  # map_fields_with_llm
+                    '{"page_type": "confirmation"}',  # verify_submission
+                ],
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.get_page_text",
+                return_value="Thank you for applying!",
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.handle_captcha_if_present",
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.take_screenshot",
+            ),
+        ):
+            result = await fill_application(state)
+
+        assert result["current_job_index"] == 1
+        assert result["total_applied"] == 1
+        assert result["jobs"][0].applied is True
+
+    @pytest.mark.asyncio
+    async def test_multi_page_form(self) -> None:
+        state = _make_state()
+        page = _mock_page()
+
+        page1_fields = [_text_field("name", "Full Name")]
+        page2_fields = [_text_field("email", "Email")]
+
+        form_fields_calls = [page1_fields, page2_fields]
+        form_fields_idx = 0
+
+        async def _get_form_fields(p: Any) -> list[FormField]:
+            nonlocal form_fields_idx
+            idx = form_fields_idx
+            form_fields_idx += 1
+            if idx < len(form_fields_calls):
+                return form_fields_calls[idx]
+            return []
+
+        # Track button clicks
+        next_btn = AsyncMock()
+        next_btn.is_visible = AsyncMock(return_value=True)
+        submit_btn = AsyncMock()
+        submit_btn.is_visible = AsyncMock(return_value=True)
+
+        click_phase = 0
+
+        async def _query_selector(selector: str) -> AsyncMock | None:
+            nonlocal click_phase
+            # Page 1: next button exists
+            if click_phase == 0 and ("Next" in selector or "Continue" in selector):
+                click_phase = 1
+                return next_btn
+            # Page 2: submit button exists
+            if click_phase == 1 and ("submit" in selector.lower() or "Submit" in selector):
+                click_phase = 2
+                return submit_btn
+            return None
+
+        page.query_selector = _query_selector
+
+        with (
+            patch(
+                "apply_operator.nodes.fill_application.get_page_with_session",
+                side_effect=lambda url: _fake_session(page),
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.get_form_fields",
+                side_effect=_get_form_fields,
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.call_llm",
+                side_effect=[
+                    '{"name": "John Doe"}',
+                    '{"email": "john@example.com"}',
+                    '{"page_type": "confirmation"}',
+                ],
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.get_page_text",
+                return_value="Thank you!",
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.handle_captcha_if_present",
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.take_screenshot",
+            ),
+        ):
+            result = await fill_application(state)
+
+        assert result["total_applied"] == 1
+        assert result["jobs"][0].applied is True
+
+    @pytest.mark.asyncio
+    async def test_captcha_triggers_user_wait(self) -> None:
+        state = _make_state()
+        page = _mock_page()
+
+        with (
+            patch(
+                "apply_operator.nodes.fill_application.get_page_with_session",
+                side_effect=lambda url: _fake_session(page),
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.get_form_fields",
+                return_value=SAMPLE_FORM_FIELDS,
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.call_llm",
+                side_effect=[
+                    SAMPLE_LLM_MAPPING,
+                    '{"page_type": "confirmation"}',
+                ],
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.get_page_text",
+                return_value="Thank you!",
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.handle_captcha_if_present",
+            ) as mock_captcha,
+            patch(
+                "apply_operator.nodes.fill_application.take_screenshot",
+            ),
+        ):
+            # Make submit button clickable
+            submit_btn = AsyncMock()
+            submit_btn.is_visible = AsyncMock(return_value=True)
+
+            async def _qs(selector: str) -> AsyncMock | None:
+                if "submit" in selector.lower():
+                    return submit_btn
+                return None
+
+            page.query_selector = _qs
+
+            await fill_application(state)
+
+        # handle_captcha_if_present should be called at least twice
+        # (pre-form and pre-submit)
+        assert mock_captcha.call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_no_form_fields_advances_index(self) -> None:
+        state = _make_state()
+        page = _mock_page()
+
+        with (
+            patch(
+                "apply_operator.nodes.fill_application.get_page_with_session",
+                side_effect=lambda url: _fake_session(page),
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.get_form_fields",
+                return_value=[],
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.get_page_text",
+                return_value="Some random page",
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.call_llm",
+                return_value='{"page_type": "other"}',
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.handle_captcha_if_present",
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.take_screenshot",
+            ),
+        ):
+            result = await fill_application(state)
+
+        assert result["current_job_index"] == 1
+        # Not applied because no form was filled
+        assert result["jobs"][0].applied is not True
+
+    @pytest.mark.asyncio
+    async def test_exception_records_error_advances_index(self) -> None:
+        state = _make_state()
+
+        @asynccontextmanager
+        async def _failing_session(url: str):  # type: ignore[no-untyped-def]
+            raise ConnectionError("Browser launch failed")
+            yield  # pragma: no cover
+
+        with patch(
+            "apply_operator.nodes.fill_application.get_page_with_session",
+            side_effect=_failing_session,
+        ):
+            result = await fill_application(state)
+
+        assert result["current_job_index"] == 1
+        assert len(result["errors"]) == 1
+        assert "Browser launch failed" in result["errors"][0]
+        assert result["jobs"][0].error != ""
+
+    @pytest.mark.asyncio
+    async def test_file_upload_uses_resume_path(self) -> None:
+        state = _make_state()
+        page = _mock_page()
+
+        file_input = AsyncMock()
+        submit_btn = AsyncMock()
+        submit_btn.is_visible = AsyncMock(return_value=True)
+
+        async def _qs(selector: str) -> AsyncMock | None:
+            if selector == '[name="resume"]':
+                return file_input
+            if "submit" in selector.lower():
+                return submit_btn
+            return None
+
+        page.query_selector = _qs
+
+        fields_with_file = [_file_field("resume")]
+
+        with (
+            patch(
+                "apply_operator.nodes.fill_application.get_page_with_session",
+                side_effect=lambda url: _fake_session(page),
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.get_form_fields",
+                return_value=fields_with_file,
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.call_llm",
+                side_effect=[
+                    '{"resume": "RESUME_FILE"}',
+                    '{"page_type": "confirmation"}',
+                ],
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.get_page_text",
+                return_value="Thank you!",
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.handle_captcha_if_present",
+            ),
+            patch(
+                "apply_operator.nodes.fill_application.take_screenshot",
+            ),
+        ):
+            await fill_application(state)
+
+        file_input.set_input_files.assert_called_once_with("/tmp/resume.pdf")

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -99,6 +99,18 @@ def _fake_analyze(scores: list[float]):  # type: ignore[no-untyped-def]
     return _analyze
 
 
+def _fake_fill(state: ApplicationState) -> dict[str, Any]:
+    """Mock fill_application: mark job as applied and advance index."""
+    idx = state.current_job_index
+    jobs = list(state.jobs)
+    jobs[idx] = jobs[idx].model_copy(update={"applied": True})
+    return {
+        "jobs": jobs,
+        "current_job_index": idx + 1,
+        "total_applied": state.total_applied + 1,
+    }
+
+
 def _noop_report(state: ApplicationState) -> dict[str, Any]:
     """Mock report_results: no-op."""
     return {}
@@ -118,6 +130,7 @@ class TestFullPipeline:
             patch("apply_operator.graph.parse_resume", _fake_parse),
             patch("apply_operator.graph.search_jobs", _fake_search(jobs)),
             patch("apply_operator.graph.analyze_fit", _fake_analyze(scores)),
+            patch("apply_operator.graph.fill_application", _fake_fill),
         ]
         if mock_report:
             patches.append(patch("apply_operator.graph.report_results", _noop_report))


### PR DESCRIPTION
## Summary

- Implement the real `fill_application` node replacing the stub with full Playwright + LLM-powered form automation
- Add browser utilities for form field extraction (`get_form_fields`), CAPTCHA detection (`detect_captcha`, `handle_captcha_if_present`), and `FormField` TypedDict
- Enhance `MAP_FORM_FIELDS` prompt with job context, field type instructions, and cover letter support; add `DETECT_FORM_PAGE_TYPE` prompt for post-submit verification
- Add 26 tests covering all helpers and node integration scenarios

## Motivation

Resolves https://github.com/takeshi-su57/apply-operator/issues/17

This is the core value proposition of the agent — automating the tedious job application form-filling process. The node uses LLM-guided field mapping instead of hardcoded selectors, making it work across different job sites. CAPTCHA/bot detection pauses for user intervention rather than attempting automated solving.

## Changes

### `src/apply_operator/tools/browser.py`
- Added `FormField` TypedDict for structured form field metadata
- Added `get_form_fields(page)` — JavaScript evaluation extracting all fillable fields with label resolution, CSS selectors, and select options
- Added `detect_captcha(page)` — checks DOM selectors (reCAPTCHA, hCaptcha, etc.) and page text indicators
- Added `handle_captcha_if_present(page)` — pauses for user if CAPTCHA detected

### `src/apply_operator/prompts/form_filling.py`
- Enhanced `MAP_FORM_FIELDS` with `{job_title}`, `{company}`, `{summary}` placeholders and explicit field type instructions (checkbox → "true"/"false", file → "RESUME_FILE", select → exact option text)
- Added `DETECT_FORM_PAGE_TYPE` prompt for classifying post-submit pages as confirmation/form/error/other

### `src/apply_operator/nodes/fill_application.py`
- Replaced sync stub with full async node (363 lines)
- Multi-page form loop (max 10 pages) with Next/Continue → Submit detection
- Field filling by type: text, email, select, checkbox, radio, file upload
- LLM-powered field mapping via `_map_fields_with_llm()`
- Post-submit verification via text heuristics + LLM classification
- Evidence screenshots saved to `data/screenshots/`
- Errors recorded in `job.error` and `state.errors`, pipeline continues

### `tests/test_fill_application.py` (new)
- 26 tests across 7 classes: `TestStripMarkdownJson`, `TestMapFieldsWithLlm`, `TestFillField`, `TestFindAndClick`, `TestVerifySubmission`, `TestFillApplication`
- Covers: single-page, multi-page, CAPTCHA triggering, no fields, exceptions, file upload

### `tests/test_graph.py`
- Added sync `_fake_fill` wrapper for graph integration tests (node is now async)

## How to Test

```bash
# Run fill_application tests
pytest tests/test_fill_application.py -v

# Run full suite (119 tests)
pytest

# Lint + type check
ruff check src/ tests/
mypy src/
```
For manual E2E testing with a real job site:


playwright install
python -m apply_operator run --resume resume.pdf --urls urls.txt

Checklist

- [x]  Self-reviewed the code
- [x]  Added/updated tests (26 new tests)
- [x]  No new warnings or errors
- [x]  ruff check and mypy pass
- [x]  All 119 tests pass
- [x]  Updated issue documentation

Open Items
 Manual E2E test with a real job application form (acceptance criterion #4)

