### PR TITLE
refactor(state): migrate ApplicationState to TypedDict with reducers

### DIFF
--- a/docs/issues/013-state-model-refinement.md
+++ b/docs/issues/013-state-model-refinement.md
@@ -5,23 +5,25 @@
 
 ## Description
 
-After the first working pipeline, refine `ApplicationState` based on what worked and what didn't. Evaluate migrating from Pydantic `BaseModel` to `TypedDict` with LangGraph reducers, and add/remove fields discovered during implementation.
+Migrate `ApplicationState` from Pydantic `BaseModel` to `TypedDict` with LangGraph reducers. The `errors` field now uses `Annotated[list[str], operator.add]` so each node returns only its new errors and the framework handles accumulation.
+
+`ResumeData` and `JobListing` remain Pydantic `BaseModel` for validation.
 
 ## Motivation
 
-- The initial state model was designed before implementation — real usage reveals gaps
-- LangGraph natively uses `TypedDict` with `Annotated` reducers; Pydantic may cause friction
-- Reducers prevent common bugs (e.g., `errors` being overwritten instead of appended)
+- LangGraph natively uses `TypedDict` with `Annotated` reducers
+- The `errors` field was fragile: nodes had to manually copy and re-include all prior errors (`[*state.errors, "new"]`), and a node returning `{"errors": ["new"]}` would silently overwrite all prior errors
+- With `operator.add` reducer, nodes return only new errors and the framework concatenates automatically
 
-## Proposed Solution
+## Implementation
 
-### Evaluate TypedDict migration
+### TypedDict with reducer
 
 ```python
-from typing import TypedDict, Annotated
 import operator
+from typing import Annotated, TypedDict
 
-class ApplicationState(TypedDict):
+class ApplicationState(TypedDict, total=False):
     resume_path: str
     job_urls: list[str]
     resume: ResumeData
@@ -29,39 +31,63 @@ class ApplicationState(TypedDict):
     current_job_index: int
     total_applied: int
     total_skipped: int
-    errors: Annotated[list[str], operator.add]  # append, don't replace
+    errors: Annotated[list[str], operator.add]
 ```
 
-### Reducer concept
+### Key behavioral change
 
-Without reducer: `errors` is replaced by the return value.
-With `operator.add` reducer: `errors` is **appended** to. Multiple nodes can add errors without overwriting each other.
+**Before:** Nodes had to manually preserve prior errors:
+```python
+errors = list(state.errors)
+errors.append("new error")
+return {"errors": errors}
+```
 
-### Potential new fields
+**After:** Nodes return only new errors:
+```python
+return {"errors": ["new error"]}
+```
 
-- `cover_letter: str` — if cover letter generation is added (issue 014)
-- `screenshots: list[str]` — debug screenshot paths
-- `start_time: float` — for duration tracking
+### State access pattern change
+
+All node and routing functions changed from attribute access to dict access:
+- `state.resume_path` -> `state["resume_path"]`
+- `state.jobs[idx]` -> `state["jobs"][idx]`
+- `state.resume.name` -> `state["resume"].name` (ResumeData is still Pydantic)
+
+### Streaming error accumulation
+
+In `main.py`, streaming events now contain only per-node errors. The `_run_graph` function accumulates errors with `extend()` instead of `update()`.
 
 ## Alternatives Considered
 
-- **Keep Pydantic** — if it works well in practice, no reason to migrate. Only migrate if you hit friction.
+- **Keep Pydantic** -- would avoid the migration effort, but the error overwrite bug was a real risk and LangGraph works better with TypedDict
 
 ## Acceptance Criteria
 
-- [ ] State model is clean, well-documented, with no unused fields
-- [ ] Reducers work correctly (errors append, not replace)
-- [ ] All nodes and tests updated for new state shape
-- [ ] All tests pass
-- [ ] `ruff check` and `mypy` pass
+- [x] State model is clean, well-documented, with no unused fields
+- [x] Reducers work correctly (errors append, not replace)
+- [x] All nodes and tests updated for new state shape
+- [x] All tests pass (193 tests)
+- [x] `ruff check` and `mypy` pass
 
 ## Files Touched
 
-- `src/apply_operator/state.py` — refine or migrate
-- `src/apply_operator/nodes/*.py` — update for new state shape
-- `src/apply_operator/graph.py` — update if TypedDict changes needed
-- `tests/conftest.py` — update fixtures
-- `tests/*.py` — update for new state shape
+- `src/apply_operator/state.py` -- `ApplicationState` migrated to TypedDict
+- `src/apply_operator/graph.py` -- dict access in routing functions
+- `src/apply_operator/nodes/parse_resume.py` -- dict access + reducer errors
+- `src/apply_operator/nodes/search_jobs.py` -- dict access + reducer errors
+- `src/apply_operator/nodes/analyze_fit.py` -- dict access + reducer errors
+- `src/apply_operator/nodes/fill_application.py` -- dict access + reducer errors
+- `src/apply_operator/nodes/report_results.py` -- dict access
+- `src/apply_operator/main.py` -- dict initial state, streaming error accumulation, simplified `_print_results`
+- `tests/conftest.py` -- `sample_state` fixture as dict
+- `tests/test_graph.py` -- dict state, dict access in fakes
+- `tests/test_checkpoint.py` -- dict state, dict access in fakes
+- `tests/test_parse_resume.py` -- dict state, updated error test
+- `tests/test_analyze_fit.py` -- dict state, updated error test
+- `tests/test_fill_application.py` -- dict state
+- `tests/test_search_jobs.py` -- dict state
 
 ## Related Issues
 

--- a/src/apply_operator/graph.py
+++ b/src/apply_operator/graph.py
@@ -20,11 +20,11 @@ def should_apply(state: ApplicationState) -> str:
     analyze_fit scores the job at current_job_index without advancing.
     This function checks that scored job and routes accordingly.
     """
-    idx = state.current_job_index
-    if idx >= len(state.jobs):
+    idx = state["current_job_index"]
+    if idx >= len(state["jobs"]):
         return "report"
 
-    current_job = state.jobs[idx]
+    current_job = state["jobs"][idx]
     if current_job.fit_score >= 0.6:
         return "apply"
     return "skip"
@@ -32,7 +32,7 @@ def should_apply(state: ApplicationState) -> str:
 
 def has_more_jobs(state: ApplicationState) -> str:
     """Check if there are more jobs to process."""
-    if state.current_job_index < len(state.jobs):
+    if state["current_job_index"] < len(state["jobs"]):
         return "next"
     return "done"
 
@@ -40,8 +40,8 @@ def has_more_jobs(state: ApplicationState) -> str:
 def skip_job(state: ApplicationState) -> dict[str, Any]:
     """Advance past a low-scoring job, incrementing the skip counter."""
     return {
-        "current_job_index": state.current_job_index + 1,
-        "total_skipped": state.total_skipped + 1,
+        "current_job_index": state["current_job_index"] + 1,
+        "total_skipped": state["total_skipped"] + 1,
     }
 
 

--- a/src/apply_operator/main.py
+++ b/src/apply_operator/main.py
@@ -68,7 +68,14 @@ def run(
     async def _run_with_checkpoint() -> tuple[dict[str, Any], float, dict[str, float]]:
         async with create_async_checkpointer() as checkpointer:
             graph = build_graph(checkpointer=checkpointer)
-            initial = ApplicationState(resume_path=str(resume), job_urls=job_urls)
+            initial: ApplicationState = {
+                "resume_path": str(resume),
+                "job_urls": job_urls,
+                "current_job_index": 0,
+                "total_applied": 0,
+                "total_skipped": 0,
+                "errors": [],
+            }
             config = {"configurable": {"thread_id": thread_id}}
             return await _run_graph(graph, initial, verbose, config=config)
 
@@ -151,6 +158,13 @@ async def _run_graph(
 
                 # Extract progress counters from node output
                 if node_output:
+                    # Accumulate errors via extend (reducer returns only new errors)
+                    if "errors" in node_output:
+                        final_state.setdefault("errors", [])
+                        final_state["errors"].extend(node_output["errors"])
+                        error_count = len(final_state["errors"])
+                        # Remove from node_output before update to avoid overwrite
+                        node_output = {k: v for k, v in node_output.items() if k != "errors"}
                     final_state.update(node_output)
                     if "jobs" in node_output:
                         total_jobs = len(node_output["jobs"])
@@ -160,8 +174,6 @@ async def _run_graph(
                         skipped = node_output["total_skipped"]
                     if "current_job_index" in node_output:
                         processed = node_output["current_job_index"]
-                    if "errors" in node_output:
-                        error_count = len(node_output["errors"])
 
             elapsed = now - pipeline_start
             live.update(
@@ -212,7 +224,7 @@ def parse_resume(
     from apply_operator.nodes.parse_resume import parse_resume as _parse_resume
     from apply_operator.state import ApplicationState
 
-    state = ApplicationState(resume_path=str(resume))
+    state: ApplicationState = {"resume_path": str(resume)}
     result = _parse_resume(state)
     resume_data = result.get("resume")
 
@@ -361,11 +373,11 @@ def _print_results(
     table.add_column("Status")
 
     for job in state.get("jobs", []):
-        title = job.title if hasattr(job, "title") else job.get("title", "Unknown")
-        company = job.company if hasattr(job, "company") else job.get("company", "Unknown")
-        fit_score = job.fit_score if hasattr(job, "fit_score") else job.get("fit_score", 0)
-        applied = job.applied if hasattr(job, "applied") else job.get("applied", False)
-        error = job.error if hasattr(job, "error") else job.get("error", "")
+        title = job.title
+        company = job.company
+        fit_score = job.fit_score
+        applied = job.applied
+        error = job.error
 
         if error:
             status = f"[red]Error: {error}[/red]"

--- a/src/apply_operator/nodes/analyze_fit.py
+++ b/src/apply_operator/nodes/analyze_fit.py
@@ -48,16 +48,17 @@ def analyze_fit(state: ApplicationState) -> dict[str, Any]:
     Scores the job at current_job_index without advancing the index.
     The graph's conditional edges handle routing (apply/skip/report).
     """
-    idx = state.current_job_index
-    if idx >= len(state.jobs):
+    idx = state["current_job_index"]
+    if idx >= len(state["jobs"]):
         return {}
 
-    job = state.jobs[idx]
+    job = state["jobs"][idx]
 
+    resume = state["resume"]
     prompt = ANALYZE_FIT.format(
-        name=state.resume.name,
-        skills=", ".join(state.resume.skills) if state.resume.skills else "None listed",
-        experience=_format_experience(state.resume.experience),
+        name=resume.name,
+        skills=", ".join(resume.skills) if resume.skills else "None listed",
+        experience=_format_experience(resume.experience),
         job_title=job.title,
         company=job.company,
         job_description=job.description,
@@ -65,7 +66,7 @@ def analyze_fit(state: ApplicationState) -> dict[str, Any]:
 
     score = 0.0
     reasoning = ""
-    errors = list(state.errors)
+    errors: list[str] = []
 
     try:
         response = call_llm(
@@ -101,10 +102,10 @@ def analyze_fit(state: ApplicationState) -> dict[str, Any]:
         reasoning or "no reasoning",
     )
 
-    updated_jobs = list(state.jobs)
+    updated_jobs = list(state["jobs"])
     updated_jobs[idx] = job.model_copy(update={"fit_score": score})
 
     result: dict[str, Any] = {"jobs": updated_jobs}
-    if errors != list(state.errors):
+    if errors:
         result["errors"] = errors
     return result

--- a/src/apply_operator/nodes/fill_application.py
+++ b/src/apply_operator/nodes/fill_application.py
@@ -259,10 +259,10 @@ async def fill_application(state: ApplicationState) -> dict[str, Any]:
     uses LLM to determine appropriate values from resume data,
     fills the form, handles CAPTCHAs, and submits.
     """
-    idx = state.current_job_index
-    jobs = list(state.jobs)
+    idx = state["current_job_index"]
+    jobs = list(state["jobs"])
     job = jobs[idx]
-    errors = list(state.errors)
+    errors: list[str] = []
 
     try:
         async with get_page_with_session(job.url) as page:
@@ -284,7 +284,7 @@ async def fill_application(state: ApplicationState) -> dict[str, Any]:
                 logger.info("Page %d: found %d form fields", page_num + 1, len(fields))
 
                 # LLM maps resume data to form fields
-                mapping = _map_fields_with_llm(fields, state.resume, job)
+                mapping = _map_fields_with_llm(fields, state["resume"], job)
                 if not mapping:
                     logger.warning("LLM returned empty field mapping on page %d", page_num + 1)
 
@@ -294,7 +294,7 @@ async def fill_application(state: ApplicationState) -> dict[str, Any]:
                     value = mapping.get(field["name"], "")
                     if not value:
                         continue
-                    await _fill_field(page, field, value, state.resume_path)
+                    await _fill_field(page, field, value, state["resume_path"])
                     filled_count += 1
 
                 logger.info(
@@ -340,7 +340,7 @@ async def fill_application(state: ApplicationState) -> dict[str, Any]:
             return {
                 "jobs": jobs,
                 "current_job_index": idx + 1,
-                "total_applied": state.total_applied + 1,
+                "total_applied": state["total_applied"] + 1,
             }
         else:
             msg = f"Submission not confirmed for {job.title} at {job.company}"
@@ -350,7 +350,7 @@ async def fill_application(state: ApplicationState) -> dict[str, Any]:
             return {
                 "jobs": jobs,
                 "current_job_index": idx + 1,
-                "total_skipped": state.total_skipped + 1,
+                "total_skipped": state["total_skipped"] + 1,
                 "errors": errors,
             }
 
@@ -364,7 +364,7 @@ async def fill_application(state: ApplicationState) -> dict[str, Any]:
         return {
             "jobs": jobs,
             "current_job_index": idx + 1,
-            "total_skipped": state.total_skipped + 1,
+            "total_skipped": state["total_skipped"] + 1,
             "errors": errors,
         }
     except Exception as e:

--- a/src/apply_operator/nodes/parse_resume.py
+++ b/src/apply_operator/nodes/parse_resume.py
@@ -28,7 +28,7 @@ def parse_resume(state: ApplicationState) -> dict[str, Any]:
 
     Uses PyMuPDF for text extraction, then LLM for structured parsing.
     """
-    raw_text = extract_text(state.resume_path)
+    raw_text = extract_text(state["resume_path"])
     prompt = PARSE_RESUME.format(resume_text=raw_text)
 
     try:
@@ -41,5 +41,5 @@ def parse_resume(state: ApplicationState) -> dict[str, Any]:
         raise
     except (json.JSONDecodeError, ValidationError) as e:
         resume = ResumeData(raw_text=raw_text)
-        return {"resume": resume, "errors": [*state.errors, f"Resume parse failed: {e}"]}
+        return {"resume": resume, "errors": [f"Resume parse failed: {e}"]}
     return {"resume": resume}

--- a/src/apply_operator/nodes/report_results.py
+++ b/src/apply_operator/nodes/report_results.py
@@ -18,10 +18,10 @@ def report_results(state: ApplicationState) -> dict[str, Any]:
     Writes application results to data/results.json for later review.
     """
     results = {
-        "total_applied": state.total_applied,
-        "total_skipped": state.total_skipped,
-        "errors": state.errors,
-        "jobs": [job.model_dump() for job in state.jobs],
+        "total_applied": state["total_applied"],
+        "total_skipped": state["total_skipped"],
+        "errors": state.get("errors", []),
+        "jobs": [job.model_dump() for job in state["jobs"]],
     }
 
     output_path = Path("data/results.json")
@@ -30,9 +30,9 @@ def report_results(state: ApplicationState) -> dict[str, Any]:
     logger.info(
         "Results saved to %s | applied=%d skipped=%d errors=%d",
         output_path,
-        state.total_applied,
-        state.total_skipped,
-        len(state.errors),
+        state["total_applied"],
+        state["total_skipped"],
+        len(state.get("errors", [])),
     )
 
     return {}

--- a/src/apply_operator/nodes/search_jobs.py
+++ b/src/apply_operator/nodes/search_jobs.py
@@ -112,9 +112,9 @@ async def search_jobs(state: ApplicationState) -> dict[str, Any]:
     Handles login walls via user intervention and follows pagination.
     """
     all_jobs: list[JobListing] = []
-    errors = list(state.errors)
+    errors: list[str] = []
 
-    for url in state.job_urls:
+    for url in state["job_urls"]:
         try:
             logger.info("Opening browser for %s", url)
             async with get_page_with_session(url) as page:

--- a/src/apply_operator/state.py
+++ b/src/apply_operator/state.py
@@ -1,6 +1,7 @@
 """LangGraph state definitions for the job application agent."""
 
-from typing import Any
+import operator
+from typing import Annotated, Any, TypedDict
 
 from pydantic import BaseModel, Field, model_validator
 
@@ -56,24 +57,27 @@ class JobListing(BaseModel):
     error: str = ""
 
 
-class ApplicationState(BaseModel):
+class ApplicationState(TypedDict, total=False):
     """Central state flowing through the LangGraph agent.
 
-    Nodes receive this state and return a dict of fields to update.
+    Nodes receive this state as a dict and return a dict of fields to update.
+    The ``errors`` field uses an ``operator.add`` reducer so that each node
+    can return only its *new* errors and LangGraph concatenates them
+    automatically.
     """
 
     # Inputs
-    resume_path: str = ""
-    job_urls: list[str] = Field(default_factory=list)
+    resume_path: str
+    job_urls: list[str]
 
     # Parsed resume
-    resume: ResumeData = Field(default_factory=ResumeData)
+    resume: ResumeData
 
     # Job search results
-    jobs: list[JobListing] = Field(default_factory=list)
-    current_job_index: int = 0
+    jobs: list[JobListing]
+    current_job_index: int
 
     # Tracking
-    total_applied: int = 0
-    total_skipped: int = 0
-    errors: list[str] = Field(default_factory=list)
+    total_applied: int
+    total_skipped: int
+    errors: Annotated[list[str], operator.add]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,13 +87,16 @@ def sample_jobs() -> list[JobListing]:
 @pytest.fixture
 def sample_state(sample_resume: ResumeData, sample_jobs: list[JobListing]) -> ApplicationState:
     """Sample application state for testing."""
-    return ApplicationState(
-        resume_path="test_resume.pdf",
-        job_urls=["https://example.com/jobs"],
-        resume=sample_resume,
-        jobs=sample_jobs,
-        current_job_index=0,
-    )
+    return {
+        "resume_path": "test_resume.pdf",
+        "job_urls": ["https://example.com/jobs"],
+        "resume": sample_resume,
+        "jobs": sample_jobs,
+        "current_job_index": 0,
+        "total_applied": 0,
+        "total_skipped": 0,
+        "errors": [],
+    }
 
 
 @pytest.fixture

--- a/tests/test_analyze_fit.py
+++ b/tests/test_analyze_fit.py
@@ -39,12 +39,16 @@ class TestAnalyzeFit:
                     description="Looking for a Python developer with Django experience.",
                 ),
             ]
-        return ApplicationState(
-            resume=resume,
-            jobs=jobs,
-            current_job_index=current_job_index,
-            errors=errors or [],
-        )
+        return {
+            "resume": resume,
+            "jobs": jobs,
+            "current_job_index": current_job_index,
+            "errors": errors or [],
+            "resume_path": "",
+            "job_urls": [],
+            "total_applied": 0,
+            "total_skipped": 0,
+        }
 
     @patch("apply_operator.nodes.analyze_fit.call_llm")
     def test_scores_job_with_valid_response(self, mock_call_llm: Any) -> None:
@@ -140,14 +144,15 @@ class TestAnalyzeFit:
         assert result["jobs"][1].fit_score == 0.9  # scored
 
     @patch("apply_operator.nodes.analyze_fit.call_llm")
-    def test_preserves_existing_errors(self, mock_call_llm: Any) -> None:
+    def test_returns_only_new_errors(self, mock_call_llm: Any) -> None:
+        """With the reducer, nodes return only new errors (framework accumulates)."""
         mock_call_llm.return_value = "not json"
-        state = self._make_state(errors=["previous error"])
+        state = self._make_state()
 
         result = analyze_fit(state)
 
-        assert "previous error" in result["errors"]
-        assert len(result["errors"]) == 2
+        assert len(result["errors"]) == 1
+        assert "Fit analysis failed" in result["errors"][0]
 
     @patch("apply_operator.nodes.analyze_fit.call_llm")
     def test_prompt_includes_resume_and_job_data(self, mock_call_llm: Any) -> None:
@@ -169,14 +174,14 @@ class TestSkipJob:
     def test_advances_index_and_increments_skipped(self) -> None:
         from apply_operator.graph import skip_job
 
-        state = ApplicationState(
-            jobs=[
+        state: ApplicationState = {
+            "jobs": [
                 JobListing(url="https://example.com/1", fit_score=0.3),
                 JobListing(url="https://example.com/2"),
             ],
-            current_job_index=0,
-            total_skipped=0,
-        )
+            "current_job_index": 0,
+            "total_skipped": 0,
+        }
 
         result = skip_job(state)
 
@@ -190,46 +195,46 @@ class TestShouldApply:
     def test_routes_apply_for_high_score(self) -> None:
         from apply_operator.graph import should_apply
 
-        state = ApplicationState(
-            jobs=[JobListing(url="https://example.com/1", fit_score=0.8)],
-            current_job_index=0,
-        )
+        state: ApplicationState = {
+            "jobs": [JobListing(url="https://example.com/1", fit_score=0.8)],
+            "current_job_index": 0,
+        }
 
         assert should_apply(state) == "apply"
 
     def test_routes_skip_for_low_score(self) -> None:
         from apply_operator.graph import should_apply
 
-        state = ApplicationState(
-            jobs=[JobListing(url="https://example.com/1", fit_score=0.3)],
-            current_job_index=0,
-        )
+        state: ApplicationState = {
+            "jobs": [JobListing(url="https://example.com/1", fit_score=0.3)],
+            "current_job_index": 0,
+        }
 
         assert should_apply(state) == "skip"
 
     def test_routes_apply_at_threshold(self) -> None:
         from apply_operator.graph import should_apply
 
-        state = ApplicationState(
-            jobs=[JobListing(url="https://example.com/1", fit_score=0.6)],
-            current_job_index=0,
-        )
+        state: ApplicationState = {
+            "jobs": [JobListing(url="https://example.com/1", fit_score=0.6)],
+            "current_job_index": 0,
+        }
 
         assert should_apply(state) == "apply"
 
     def test_routes_report_when_all_processed(self) -> None:
         from apply_operator.graph import should_apply
 
-        state = ApplicationState(
-            jobs=[JobListing(url="https://example.com/1", fit_score=0.8)],
-            current_job_index=1,
-        )
+        state: ApplicationState = {
+            "jobs": [JobListing(url="https://example.com/1", fit_score=0.8)],
+            "current_job_index": 1,
+        }
 
         assert should_apply(state) == "report"
 
     def test_routes_report_for_empty_jobs(self) -> None:
         from apply_operator.graph import should_apply
 
-        state = ApplicationState(jobs=[], current_job_index=0)
+        state: ApplicationState = {"jobs": [], "current_job_index": 0}
 
         assert should_apply(state) == "report"

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -64,10 +64,10 @@ def _fake_analyze(scores: list[float]):  # type: ignore[no-untyped-def]
 
     def _analyze(state: ApplicationState) -> dict[str, Any]:
         nonlocal call_count
-        idx = state.current_job_index
-        if idx >= len(state.jobs):
+        idx = state["current_job_index"]
+        if idx >= len(state["jobs"]):
             return {}
-        updated_jobs = list(state.jobs)
+        updated_jobs = list(state["jobs"])
         updated_jobs[idx] = updated_jobs[idx].model_copy(update={"fit_score": scores[call_count]})
         call_count += 1
         return {"jobs": updated_jobs}
@@ -76,13 +76,13 @@ def _fake_analyze(scores: list[float]):  # type: ignore[no-untyped-def]
 
 
 def _fake_fill(state: ApplicationState) -> dict[str, Any]:
-    idx = state.current_job_index
-    jobs = list(state.jobs)
+    idx = state["current_job_index"]
+    jobs = list(state["jobs"])
     jobs[idx] = jobs[idx].model_copy(update={"applied": True})
     return {
         "jobs": jobs,
         "current_job_index": idx + 1,
-        "total_applied": state.total_applied + 1,
+        "total_applied": state["total_applied"] + 1,
     }
 
 
@@ -167,7 +167,7 @@ class TestCheckpointSaveAndResume:
 
         config = {"configurable": {"thread_id": "test-save-1"}}
         await graph.ainvoke(
-            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"]),
+            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0},
             config=config,
         )
 
@@ -186,7 +186,7 @@ class TestCheckpointSaveAndResume:
 
         config = {"configurable": {"thread_id": "test-no-rerun"}}
         await graph.ainvoke(
-            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"]),
+            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0},
             config=config,
         )
 
@@ -210,7 +210,7 @@ class TestCheckpointSaveAndResume:
         config1 = {"configurable": {"thread_id": "test-isolation-1"}}
         config2 = {"configurable": {"thread_id": "test-isolation-2"}}
 
-        initial = ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+        initial = {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
 
         result1 = await graph1.ainvoke(initial, config=config1)
         result2 = await graph2.ainvoke(initial, config=config2)
@@ -249,7 +249,7 @@ class TestCheckpointSaveAndResume:
             graph = build_graph(checkpointer=async_checkpoint_saver)
 
             config = {"configurable": {"thread_id": "test-resume"}}
-            initial = ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+            initial = {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
 
             with pytest.raises(RuntimeError, match="Simulated crash"):
                 await graph.ainvoke(initial, config=config)
@@ -284,7 +284,7 @@ class TestGetRunSummaries:
 
         config = {"configurable": {"thread_id": "test-list-completed"}}
         await graph.ainvoke(
-            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"]),
+            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0},
             config=config,
         )
 
@@ -319,7 +319,7 @@ class TestGetRunSummaries:
             config = {"configurable": {"thread_id": "test-list-interrupted"}}
             with pytest.raises(RuntimeError):
                 await graph.ainvoke(
-                    ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"]),
+                    {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0},
                     config=config,
                 )
 

--- a/tests/test_fill_application.py
+++ b/tests/test_fill_application.py
@@ -53,7 +53,10 @@ def _make_state(**kwargs: Any) -> ApplicationState:
         "current_job_index": 0,
     }
     defaults.update(kwargs)
-    return ApplicationState(**defaults)
+    defaults.setdefault("total_applied", 0)
+    defaults.setdefault("total_skipped", 0)
+    defaults.setdefault("errors", [])
+    return defaults
 
 
 def _mock_page(url: str = "https://example.com/apply/1") -> AsyncMock:

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -88,10 +88,10 @@ def _fake_analyze(scores: list[float]):  # type: ignore[no-untyped-def]
 
     def _analyze(state: ApplicationState) -> dict[str, Any]:
         nonlocal call_count
-        idx = state.current_job_index
-        if idx >= len(state.jobs):
+        idx = state["current_job_index"]
+        if idx >= len(state["jobs"]):
             return {}
-        updated_jobs = list(state.jobs)
+        updated_jobs = list(state["jobs"])
         updated_jobs[idx] = updated_jobs[idx].model_copy(update={"fit_score": scores[call_count]})
         call_count += 1
         return {"jobs": updated_jobs}
@@ -101,13 +101,13 @@ def _fake_analyze(scores: list[float]):  # type: ignore[no-untyped-def]
 
 def _fake_fill(state: ApplicationState) -> dict[str, Any]:
     """Mock fill_application: mark job as applied and advance index."""
-    idx = state.current_job_index
-    jobs = list(state.jobs)
+    idx = state["current_job_index"]
+    jobs = list(state["jobs"])
     jobs[idx] = jobs[idx].model_copy(update={"applied": True})
     return {
         "jobs": jobs,
         "current_job_index": idx + 1,
-        "total_applied": state.total_applied + 1,
+        "total_applied": state["total_applied"] + 1,
     }
 
 
@@ -152,7 +152,7 @@ class TestFullPipeline:
 
         graph = self._build_mocked_graph(jobs, scores)
         result = await graph.ainvoke(
-            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
         )
 
         assert result["total_applied"] == 2
@@ -169,7 +169,7 @@ class TestFullPipeline:
         """Pipeline terminates cleanly when no jobs are found."""
         graph = self._build_mocked_graph(jobs=[], scores=[])
         result = await graph.ainvoke(
-            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
         )
 
         assert result["total_applied"] == 0
@@ -183,7 +183,7 @@ class TestFullPipeline:
 
         graph = self._build_mocked_graph(jobs, scores)
         result = await graph.ainvoke(
-            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
         )
 
         assert result["total_applied"] == 0
@@ -198,7 +198,7 @@ class TestFullPipeline:
 
         graph = self._build_mocked_graph(jobs, scores)
         result = await graph.ainvoke(
-            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
         )
 
         assert result["total_applied"] == 2
@@ -213,7 +213,7 @@ class TestFullPipeline:
 
         graph = self._build_mocked_graph(jobs, scores)
         result = await graph.ainvoke(
-            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
         )
 
         assert result["total_applied"] == 1
@@ -228,7 +228,7 @@ class TestFullPipeline:
 
         graph = self._build_mocked_graph(jobs, scores)
         result = await graph.ainvoke(
-            ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
         )
 
         assert result["total_applied"] == 0
@@ -255,7 +255,7 @@ class TestFullPipeline:
             mock_path_obj.write_text.side_effect = lambda text: output_path.write_text(text)
 
             await graph.ainvoke(
-                ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+                {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
             )
 
         assert output_path.exists()
@@ -270,7 +270,7 @@ class TestFullPipeline:
         scores = [0.7]
 
         graph = self._build_mocked_graph(jobs, scores)
-        initial = ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+        initial = {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
 
         node_names: list[str] = []
         async for event in graph.astream(initial, stream_mode="updates"):
@@ -294,7 +294,7 @@ class TestFullPipeline:
         graph1 = self._build_mocked_graph(jobs, scores)
         graph2 = self._build_mocked_graph(jobs, [0.8, 0.4])
 
-        initial = ApplicationState(resume_path="test.pdf", job_urls=["https://example.com"])
+        initial = {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
 
         # Get result via ainvoke
         invoke_result = await graph1.ainvoke(initial)

--- a/tests/test_parse_resume.py
+++ b/tests/test_parse_resume.py
@@ -52,7 +52,7 @@ class TestParseResume:
         mock_extract.return_value = "John Doe\njohn@example.com"
         mock_llm.return_value = VALID_LLM_RESPONSE
 
-        state = ApplicationState(resume_path="resume.pdf")
+        state = {"resume_path": "resume.pdf"}
         result = parse_resume(state)
 
         assert "resume" in result
@@ -73,7 +73,7 @@ class TestParseResume:
         mock_extract.return_value = "some resume text"
         mock_llm.return_value = "not valid json at all"
 
-        state = ApplicationState(resume_path="resume.pdf")
+        state = {"resume_path": "resume.pdf"}
         result = parse_resume(state)
 
         assert result["resume"].raw_text == "some resume text"
@@ -87,7 +87,7 @@ class TestParseResume:
         mock_extract.return_value = "John Doe\njohn@example.com"
         mock_llm.return_value = f"```json\n{VALID_LLM_RESPONSE}\n```"
 
-        state = ApplicationState(resume_path="resume.pdf")
+        state = {"resume_path": "resume.pdf"}
         result = parse_resume(state)
 
         assert "errors" not in result
@@ -99,7 +99,7 @@ class TestParseResume:
         mock_extract.return_value = ""
         mock_llm.return_value = json.dumps({"name": "", "email": "", "skills": []})
 
-        state = ApplicationState(resume_path="resume.pdf")
+        state = {"resume_path": "resume.pdf"}
         result = parse_resume(state)
 
         assert result["resume"].raw_text == ""
@@ -120,7 +120,7 @@ class TestParseResume:
             }
         )
 
-        state = ApplicationState(resume_path="resume.pdf")
+        state = {"resume_path": "resume.pdf"}
         result = parse_resume(state)
 
         assert "errors" not in result
@@ -140,7 +140,7 @@ class TestParseResume:
         # skills should be a list, not a string — triggers ValidationError
         mock_llm.return_value = json.dumps({"skills": 12345})
 
-        state = ApplicationState(resume_path="resume.pdf")
+        state = {"resume_path": "resume.pdf"}
         result = parse_resume(state)
 
         assert result["resume"].raw_text == "some text"
@@ -149,12 +149,13 @@ class TestParseResume:
 
     @patch("apply_operator.nodes.parse_resume.call_llm")
     @patch("apply_operator.nodes.parse_resume.extract_text")
-    def test_preserves_existing_errors(self, mock_extract: Any, mock_llm: Any) -> None:
+    def test_returns_only_new_errors(self, mock_extract: Any, mock_llm: Any) -> None:
+        """With the reducer, nodes return only new errors (framework accumulates)."""
         mock_extract.return_value = "text"
         mock_llm.return_value = "bad json"
 
-        state = ApplicationState(resume_path="resume.pdf", errors=["prior error"])
+        state: ApplicationState = {"resume_path": "resume.pdf"}
         result = parse_resume(state)
 
-        assert result["errors"][0] == "prior error"
-        assert "Resume parse failed" in result["errors"][1]
+        assert len(result["errors"]) == 1
+        assert "Resume parse failed" in result["errors"][0]

--- a/tests/test_search_jobs.py
+++ b/tests/test_search_jobs.py
@@ -21,9 +21,10 @@ def _make_state(**kwargs: Any) -> ApplicationState:
     defaults: dict[str, Any] = {
         "resume_path": "test.pdf",
         "job_urls": ["https://example.com/jobs"],
+        "errors": [],
     }
     defaults.update(kwargs)
-    return ApplicationState(**defaults)
+    return defaults
 
 
 def _mock_page(url: str = "https://example.com/jobs", text: str = "") -> AsyncMock:


### PR DESCRIPTION
## Summary

- Migrate `ApplicationState` from Pydantic `BaseModel` to `TypedDict` with LangGraph `operator.add` reducer on `errors`
- Nodes now return only new errors — the framework handles accumulation, eliminating a class of silent-overwrite bugs
- `ResumeData` and `JobListing` remain Pydantic `BaseModel` for validation

## Motivation

Resolves https://github.com/takeshi-su57/apply-operator/issues/25

Every node had to manually preserve prior errors with `errors = list(state.errors); errors.append(...)`. If a node forgot and returned `{"errors": ["new"]}`, it would silently **overwrite** all prior errors. With `Annotated[list[str], operator.add]`, this entire class of bugs is eliminated — nodes return only their new errors and LangGraph concatenates automatically.

## Changes

### Core state change
- **`src/apply_operator/state.py`** — `ApplicationState` is now `TypedDict(total=False)` with `Annotated[list[str], operator.add]` on `errors`

### Node + routing updates (dict access + reducer errors)
- **`src/apply_operator/graph.py`** — `state.field` → `state["field"]` in routing functions
- **`src/apply_operator/nodes/parse_resume.py`** — `[*state.errors, "..."]` → `["..."]`
- **`src/apply_operator/nodes/search_jobs.py`** — `errors = list(state.errors)` → `errors: list[str] = []`
- **`src/apply_operator/nodes/analyze_fit.py`** — same pattern; simplified error check from `if errors != list(state.errors)` to `if errors`
- **`src/apply_operator/nodes/fill_application.py`** — same pattern across 4 error paths
- **`src/apply_operator/nodes/report_results.py`** — dict access only (no error changes)

### CLI updates
- **`src/apply_operator/main.py`** — dict initial state; streaming accumulates errors with `extend()` instead of `update()`; simplified `_print_results` (removed `hasattr` fallback)

### Test updates (10 files)
- All `ApplicationState(...)` constructors → dict literals
- `_make_state` helpers return dicts
- Fake node helpers use `state["field"]` access
- `test_preserves_existing_errors` tests renamed to `test_returns_only_new_errors` (reflects reducer semantics)

## How to Test

```bash
uv pip install -e ".[dev]"
pytest tests/ -v                    # 193 tests pass
ruff check src/ tests/              # All checks passed
mypy src/                           # No issues

# Manual: verify errors accumulate across nodes
python -m apply_operator run --resume resume.pdf --urls urls.txt
# If search_jobs AND fill_application both error, both should appear in results
```

Checklist

- [x]  Self-reviewed the code
- [x]  Added/updated tests (error tests rewritten for reducer semantics)
- [x]  No new warnings or errors
- [x]  ruff check, mypy, and pytest all pass (193 tests)
- [x]  Updated documentation (issue doc)