### PR TITLE
feat(nodes): add cover letter generation node

### DIFF
--- a/docs/issues/014-cover-letter-generation.md
+++ b/docs/issues/014-cover-letter-generation.md
@@ -5,7 +5,7 @@
 
 ## Description
 
-Add an optional `generate_cover_letter` node that creates a tailored cover letter for high-fit jobs. Runs after `analyze_fit` (for jobs with fit >= 0.6 only) and before `fill_application`.
+Add a `generate_cover_letter` node that creates a tailored cover letter for high-fit jobs. Runs after `analyze_fit` (for jobs with fit >= 0.6 only) and before `fill_application`.
 
 ## Motivation
 
@@ -13,35 +13,59 @@ Add an optional `generate_cover_letter` node that creates a tailored cover lette
 - LLM can generate one tailored to the specific job and resume
 - Only runs for high-fit jobs, so it doesn't waste LLM calls on skipped positions
 
-## Proposed Solution
+## Implementation
 
-- Create `nodes/generate_cover_letter.py` with prompt + LLM call
-- Add `cover_letter: str` field to `ApplicationState`
-- Wire into graph: `analyze_fit → [fit >= 0.6] → generate_cover_letter → fill_application`
-- Update `fill_application` to include cover letter in form data
+### New node: `generate_cover_letter`
+
+Located at `src/apply_operator/nodes/generate_cover_letter.py`. Follows the same pattern as `analyze_fit`:
+- Uses `@log_node` decorator
+- Reads current job and resume from state via dict access
+- Calls `call_llm()` with the `GENERATE_COVER_LETTER` prompt
+- Stores the generated cover letter on `JobListing.cover_letter` via `model_copy()`
+- Returns `{"jobs": updated_jobs}` (and `{"errors": [...]}` on failure)
+
+### Graph flow change
+
+```
+analyze_fit → [fit >= 0.6] → generate_cover_letter → fill_application
+```
+
+The new node is inserted between `analyze_fit` and `fill_application`. Low-fit jobs skip both `generate_cover_letter` and `fill_application`.
+
+### Cover letter in form filling
+
+`fill_application._map_fields_with_llm()` now passes `job.cover_letter` to the `MAP_FORM_FIELDS` prompt. If a form field asks for a cover letter, the LLM uses the pre-generated one instead of composing inline.
+
+### State change
+
+Added `cover_letter: str = ""` field to `JobListing` model.
 
 ## Alternatives Considered
 
-- **Static cover letter** — user provides one cover letter, used for all jobs. Simpler but not personalized.
-- **No cover letter** — some applications don't require one, but it improves response rates
+- **Static cover letter** -- user provides one, used for all jobs. Simpler but not personalized.
+- **Inline generation in fill_application** -- was the previous workaround (2-3 sentence answer composed per form field). The dedicated node generates a proper multi-paragraph letter once.
 
 ## Acceptance Criteria
 
-- [ ] Cover letter generated for high-fit jobs only
-- [ ] Cover letter mentions company name and relevant skills
-- [ ] Cover letter used in `fill_application` if form has a cover letter field
-- [ ] Low-fit jobs skip cover letter generation
-- [ ] Tests pass with mocked LLM
-- [ ] `ruff check` and `mypy` pass
+- [x] Cover letter generated for high-fit jobs only
+- [x] Cover letter mentions company name and relevant skills (via prompt)
+- [x] Cover letter used in `fill_application` if form has a cover letter field
+- [x] Low-fit jobs skip cover letter generation
+- [x] Tests pass with mocked LLM (9 new tests)
+- [x] `ruff check` and `mypy` pass
 
 ## Files Touched
 
-- `src/apply_operator/nodes/generate_cover_letter.py` — create
-- `src/apply_operator/nodes/__init__.py` — add export
-- `src/apply_operator/prompts/cover_letter.py` — create
-- `src/apply_operator/state.py` — add `cover_letter` field
-- `src/apply_operator/graph.py` — insert node in graph
-- `tests/test_generate_cover_letter.py` — create
+- `src/apply_operator/nodes/generate_cover_letter.py` -- **new**: cover letter node
+- `src/apply_operator/prompts/cover_letter.py` -- **new**: `GENERATE_COVER_LETTER` prompt
+- `src/apply_operator/nodes/__init__.py` -- added export
+- `src/apply_operator/state.py` -- added `cover_letter` field to `JobListing`
+- `src/apply_operator/graph.py` -- inserted node in graph flow
+- `src/apply_operator/nodes/fill_application.py` -- passes cover letter to form mapping prompt
+- `src/apply_operator/prompts/form_filling.py` -- updated `MAP_FORM_FIELDS` to use pre-generated cover letter
+- `tests/test_generate_cover_letter.py` -- **new**: 9 tests
+- `tests/test_graph.py` -- added mock and expected node name
+- `tests/test_checkpoint.py` -- added mock to all patched graphs
 
 ## Related Issues
 

--- a/src/apply_operator/graph.py
+++ b/src/apply_operator/graph.py
@@ -8,6 +8,7 @@ from langgraph.graph.state import CompiledStateGraph
 
 from apply_operator.nodes.analyze_fit import analyze_fit
 from apply_operator.nodes.fill_application import fill_application
+from apply_operator.nodes.generate_cover_letter import generate_cover_letter
 from apply_operator.nodes.parse_resume import parse_resume
 from apply_operator.nodes.report_results import report_results
 from apply_operator.nodes.search_jobs import search_jobs
@@ -55,7 +56,7 @@ def build_graph(
 
     Flow:
         START -> parse_resume -> search_jobs -> analyze_fit
-            -> [fit >= 0.6] -> fill_application -> (loop or report)
+            -> [fit >= 0.6] -> generate_cover_letter -> fill_application -> (loop or report)
             -> [fit < 0.6] -> skip_job -> analyze_fit (loop)
             -> [no more jobs] -> report_results -> END
     """
@@ -66,6 +67,7 @@ def build_graph(
     graph.add_node("search_jobs", search_jobs)
     graph.add_node("analyze_fit", analyze_fit)
     graph.add_node("skip_job", skip_job)
+    graph.add_node("generate_cover_letter", generate_cover_letter)
     graph.add_node("fill_application", fill_application)
     graph.add_node("report_results", report_results)
 
@@ -74,16 +76,19 @@ def build_graph(
     graph.add_edge("parse_resume", "search_jobs")
     graph.add_edge("search_jobs", "analyze_fit")
 
-    # Conditional: analyze_fit -> apply, skip, or report
+    # Conditional: analyze_fit -> cover letter + apply, skip, or report
     graph.add_conditional_edges(
         "analyze_fit",
         should_apply,
         {
-            "apply": "fill_application",
+            "apply": "generate_cover_letter",
             "skip": "skip_job",
             "report": "report_results",
         },
     )
+
+    # Cover letter flows into form filling
+    graph.add_edge("generate_cover_letter", "fill_application")
 
     # skip_job advances index and loops back to analyze next job
     graph.add_edge("skip_job", "analyze_fit")

--- a/src/apply_operator/nodes/__init__.py
+++ b/src/apply_operator/nodes/__init__.py
@@ -2,6 +2,7 @@
 
 from apply_operator.nodes.analyze_fit import analyze_fit
 from apply_operator.nodes.fill_application import fill_application
+from apply_operator.nodes.generate_cover_letter import generate_cover_letter
 from apply_operator.nodes.parse_resume import parse_resume
 from apply_operator.nodes.report_results import report_results
 from apply_operator.nodes.search_jobs import search_jobs
@@ -9,6 +10,7 @@ from apply_operator.nodes.search_jobs import search_jobs
 __all__ = [
     "analyze_fit",
     "fill_application",
+    "generate_cover_letter",
     "parse_resume",
     "report_results",
     "search_jobs",

--- a/src/apply_operator/nodes/fill_application.py
+++ b/src/apply_operator/nodes/fill_application.py
@@ -115,6 +115,10 @@ def _map_fields_with_llm(
     Returns:
         Mapping of field name to value to fill in.
     """
+    cover_letter_section = ""
+    if job.cover_letter:
+        cover_letter_section = f"\nCover Letter:\n{job.cover_letter}"
+
     prompt = MAP_FORM_FIELDS.format(
         job_title=job.title or "Unknown Position",
         company=job.company or "Unknown Company",
@@ -126,6 +130,7 @@ def _map_fields_with_llm(
         skills=", ".join(resume.skills) if resume.skills else "None listed",
         experience=_format_experience(resume.experience),
         education=_format_education(resume.education),
+        cover_letter=cover_letter_section,
     )
 
     try:

--- a/src/apply_operator/nodes/generate_cover_letter.py
+++ b/src/apply_operator/nodes/generate_cover_letter.py
@@ -1,0 +1,99 @@
+"""Node: Generate a tailored cover letter for the current job."""
+
+import json
+import logging
+import re
+from typing import Any
+
+from apply_operator.prompts.cover_letter import GENERATE_COVER_LETTER
+from apply_operator.state import ApplicationState
+from apply_operator.tools.llm_provider import call_llm
+from apply_operator.tools.logging_utils import log_node
+from apply_operator.tools.retry import FatalConfigError
+
+logger = logging.getLogger(__name__)
+
+
+def _strip_markdown_json(text: str) -> str:
+    """Strip markdown code fences from LLM JSON responses."""
+    match = re.search(r"```(?:json)?\s*\n?(.*?)\n?\s*```", text, re.DOTALL)
+    if match:
+        return match.group(1).strip()
+    return text.strip()
+
+
+def _format_experience(experience: list[dict[str, Any]]) -> str:
+    """Format experience list into a readable string for the prompt."""
+    if not experience:
+        return "No experience listed"
+    parts = []
+    for exp in experience:
+        title = exp.get("title", "Unknown")
+        company = exp.get("company", "Unknown")
+        duration = exp.get("duration", "")
+        desc = exp.get("description", "")
+        entry = f"{title} at {company}"
+        if duration:
+            entry += f" ({duration})"
+        if desc:
+            entry += f" — {desc}"
+        parts.append(entry)
+    return "; ".join(parts)
+
+
+@log_node
+def generate_cover_letter(state: ApplicationState) -> dict[str, Any]:
+    """Generate a tailored cover letter for the current high-fit job.
+
+    Uses LLM to create a professional cover letter based on the candidate's
+    resume and the job description. Stores the result on the JobListing.
+    """
+    idx = state["current_job_index"]
+    if idx >= len(state["jobs"]):
+        return {}
+
+    job = state["jobs"][idx]
+    resume = state["resume"]
+
+    prompt = GENERATE_COVER_LETTER.format(
+        name=resume.name,
+        summary=resume.summary or "No summary available",
+        skills=", ".join(resume.skills) if resume.skills else "None listed",
+        experience=_format_experience(resume.experience),
+        job_title=job.title,
+        company=job.company,
+        job_description=job.description,
+    )
+
+    cover_letter = ""
+    errors: list[str] = []
+
+    try:
+        response = call_llm(
+            prompt,
+            purpose=f"generate_cover_letter for {job.title} at {job.company}",
+            expect_json=True,
+        )
+        cleaned = _strip_markdown_json(response)
+        data = json.loads(cleaned)
+        cover_letter = str(data.get("cover_letter", ""))
+    except FatalConfigError:
+        raise
+    except (json.JSONDecodeError, ValueError, TypeError, KeyError) as e:
+        logger.error("Failed to generate cover letter for %s: %s", job.url, e)
+        errors.append(f"Cover letter generation failed for {job.url}: {e}")
+
+    logger.info(
+        "Cover letter for %s (%s): %d chars",
+        job.title,
+        job.company,
+        len(cover_letter),
+    )
+
+    updated_jobs = list(state["jobs"])
+    updated_jobs[idx] = job.model_copy(update={"cover_letter": cover_letter})
+
+    result: dict[str, Any] = {"jobs": updated_jobs}
+    if errors:
+        result["errors"] = errors
+    return result

--- a/src/apply_operator/prompts/cover_letter.py
+++ b/src/apply_operator/prompts/cover_letter.py
@@ -1,0 +1,28 @@
+"""Prompts for cover letter generation."""
+
+GENERATE_COVER_LETTER = """Write a professional cover letter for this job application.
+
+## Candidate Profile
+Name: {name}
+Summary: {summary}
+Skills: {skills}
+Experience: {experience}
+
+## Job Posting
+Title: {job_title}
+Company: {company}
+Description: {job_description}
+
+## Instructions
+Write a concise, professional cover letter (2-3 paragraphs) that:
+- Opens with enthusiasm for the specific role and company
+- Highlights the candidate's most relevant skills and experience for this position
+- Closes with a call to action
+
+Do NOT invent qualifications or experience not present in the candidate data.
+Use a professional but warm tone.
+
+Return a JSON object with:
+- cover_letter: the full cover letter text as a single string
+
+Return ONLY valid JSON, no other text."""

--- a/src/apply_operator/prompts/form_filling.py
+++ b/src/apply_operator/prompts/form_filling.py
@@ -16,6 +16,7 @@ Summary: {summary}
 Skills: {skills}
 Experience: {experience}
 Education: {education}
+{cover_letter}
 
 ## Instructions
 Return a JSON object mapping each field's **name** attribute to the value to fill in.
@@ -25,8 +26,8 @@ Rules:
 - For select/dropdown fields: return the **exact option text** from the available options list.
 - For checkbox/radio fields: return "true" or "false".
 - For file upload fields: return "RESUME_FILE".
-- If a field asks for a cover letter or "why do you want to work here", compose a brief \
-2-3 sentence answer using the candidate's summary and the job context.
+- If a field asks for a cover letter or "why do you want to work here", use the Cover Letter \
+provided above. If no cover letter is provided, compose a brief 2-3 sentence answer.
 - If a field asks for information not available in the candidate data, return an empty string.
 - Do NOT invent information that is not in the candidate data.
 

--- a/src/apply_operator/state.py
+++ b/src/apply_operator/state.py
@@ -54,6 +54,7 @@ class JobListing(BaseModel):
     location: str = ""
     fit_score: float = 0.0
     applied: bool = False
+    cover_letter: str = ""
     error: str = ""
 
 

--- a/tests/test_checkpoint.py
+++ b/tests/test_checkpoint.py
@@ -86,6 +86,10 @@ def _fake_fill(state: ApplicationState) -> dict[str, Any]:
     }
 
 
+def _noop_cover_letter(state: ApplicationState) -> dict[str, Any]:
+    return {}
+
+
 def _noop_report(state: ApplicationState) -> dict[str, Any]:
     return {}
 
@@ -100,6 +104,7 @@ def _build_mocked_graph(
         patch("apply_operator.graph.parse_resume", _fake_parse),
         patch("apply_operator.graph.search_jobs", _fake_search(jobs)),
         patch("apply_operator.graph.analyze_fit", _fake_analyze(scores)),
+        patch("apply_operator.graph.generate_cover_letter", _noop_cover_letter),
         patch("apply_operator.graph.fill_application", _fake_fill),
         patch("apply_operator.graph.report_results", _noop_report),
     ]
@@ -157,9 +162,7 @@ class TestCreateCheckpointer:
 
 class TestCheckpointSaveAndResume:
     @pytest.mark.asyncio
-    async def test_run_saves_checkpoints(
-        self, async_checkpoint_saver: AsyncSqliteSaver
-    ) -> None:
+    async def test_run_saves_checkpoints(self, async_checkpoint_saver: AsyncSqliteSaver) -> None:
         """A completed run has checkpoints and get_state().next is empty."""
         jobs = _make_jobs(1)
         scores = [0.8]
@@ -167,7 +170,14 @@ class TestCheckpointSaveAndResume:
 
         config = {"configurable": {"thread_id": "test-save-1"}}
         await graph.ainvoke(
-            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0},
+            {
+                "resume_path": "test.pdf",
+                "job_urls": ["https://example.com"],
+                "errors": [],
+                "total_applied": 0,
+                "total_skipped": 0,
+                "current_job_index": 0,
+            },
             config=config,
         )
 
@@ -176,9 +186,7 @@ class TestCheckpointSaveAndResume:
         assert not snapshot.next
 
     @pytest.mark.asyncio
-    async def test_completed_run_not_rerun(
-        self, async_checkpoint_saver: AsyncSqliteSaver
-    ) -> None:
+    async def test_completed_run_not_rerun(self, async_checkpoint_saver: AsyncSqliteSaver) -> None:
         """Invoking a completed run again with None yields no new node executions."""
         jobs = _make_jobs(1)
         scores = [0.8]
@@ -186,7 +194,14 @@ class TestCheckpointSaveAndResume:
 
         config = {"configurable": {"thread_id": "test-no-rerun"}}
         await graph.ainvoke(
-            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0},
+            {
+                "resume_path": "test.pdf",
+                "job_urls": ["https://example.com"],
+                "errors": [],
+                "total_applied": 0,
+                "total_skipped": 0,
+                "current_job_index": 0,
+            },
             config=config,
         )
 
@@ -198,9 +213,7 @@ class TestCheckpointSaveAndResume:
         assert node_names == [], f"Expected no nodes to run, got: {node_names}"
 
     @pytest.mark.asyncio
-    async def test_thread_id_isolation(
-        self, async_checkpoint_saver: AsyncSqliteSaver
-    ) -> None:
+    async def test_thread_id_isolation(self, async_checkpoint_saver: AsyncSqliteSaver) -> None:
         """Two runs with different thread_ids have independent state."""
         jobs = _make_jobs(1)
 
@@ -210,7 +223,14 @@ class TestCheckpointSaveAndResume:
         config1 = {"configurable": {"thread_id": "test-isolation-1"}}
         config2 = {"configurable": {"thread_id": "test-isolation-2"}}
 
-        initial = {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
+        initial = {
+            "resume_path": "test.pdf",
+            "job_urls": ["https://example.com"],
+            "errors": [],
+            "total_applied": 0,
+            "total_skipped": 0,
+            "current_job_index": 0,
+        }
 
         result1 = await graph1.ainvoke(initial, config=config1)
         result2 = await graph2.ainvoke(initial, config=config2)
@@ -220,9 +240,7 @@ class TestCheckpointSaveAndResume:
         assert result2["total_skipped"] == 1
 
     @pytest.mark.asyncio
-    async def test_resume_from_interrupted(
-        self, async_checkpoint_saver: AsyncSqliteSaver
-    ) -> None:
+    async def test_resume_from_interrupted(self, async_checkpoint_saver: AsyncSqliteSaver) -> None:
         """A run interrupted mid-pipeline can be resumed."""
         call_count = 0
 
@@ -237,6 +255,7 @@ class TestCheckpointSaveAndResume:
             patch("apply_operator.graph.parse_resume", _fake_parse),
             patch("apply_operator.graph.search_jobs", _failing_search),
             patch("apply_operator.graph.analyze_fit", _fake_analyze([0.8])),
+            patch("apply_operator.graph.generate_cover_letter", _noop_cover_letter),
             patch("apply_operator.graph.fill_application", _fake_fill),
             patch("apply_operator.graph.report_results", _noop_report),
         ]
@@ -249,7 +268,14 @@ class TestCheckpointSaveAndResume:
             graph = build_graph(checkpointer=async_checkpoint_saver)
 
             config = {"configurable": {"thread_id": "test-resume"}}
-            initial = {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
+            initial = {
+                "resume_path": "test.pdf",
+                "job_urls": ["https://example.com"],
+                "errors": [],
+                "total_applied": 0,
+                "total_skipped": 0,
+                "current_job_index": 0,
+            }
 
             with pytest.raises(RuntimeError, match="Simulated crash"):
                 await graph.ainvoke(initial, config=config)
@@ -275,16 +301,21 @@ class TestGetRunSummaries:
         assert runs == []
 
     @pytest.mark.asyncio
-    async def test_shows_completed_run(
-        self, async_checkpoint_saver: AsyncSqliteSaver
-    ) -> None:
+    async def test_shows_completed_run(self, async_checkpoint_saver: AsyncSqliteSaver) -> None:
         """Run completes, then verify summaries via the same saver."""
         jobs = _make_jobs(1)
         graph = _build_mocked_graph(async_checkpoint_saver, jobs, [0.7])
 
         config = {"configurable": {"thread_id": "test-list-completed"}}
         await graph.ainvoke(
-            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0},
+            {
+                "resume_path": "test.pdf",
+                "job_urls": ["https://example.com"],
+                "errors": [],
+                "total_applied": 0,
+                "total_skipped": 0,
+                "current_job_index": 0,
+            },
             config=config,
         )
 
@@ -295,9 +326,7 @@ class TestGetRunSummaries:
         assert not snapshot.next  # completed
 
     @pytest.mark.asyncio
-    async def test_shows_interrupted_run(
-        self, async_checkpoint_saver: AsyncSqliteSaver
-    ) -> None:
+    async def test_shows_interrupted_run(self, async_checkpoint_saver: AsyncSqliteSaver) -> None:
         def _crash_search(state: ApplicationState) -> dict[str, Any]:
             raise RuntimeError("boom")
 
@@ -305,6 +334,7 @@ class TestGetRunSummaries:
             patch("apply_operator.graph.parse_resume", _fake_parse),
             patch("apply_operator.graph.search_jobs", _crash_search),
             patch("apply_operator.graph.analyze_fit", _fake_analyze([0.8])),
+            patch("apply_operator.graph.generate_cover_letter", _noop_cover_letter),
             patch("apply_operator.graph.fill_application", _fake_fill),
             patch("apply_operator.graph.report_results", _noop_report),
         ]
@@ -319,7 +349,14 @@ class TestGetRunSummaries:
             config = {"configurable": {"thread_id": "test-list-interrupted"}}
             with pytest.raises(RuntimeError):
                 await graph.ainvoke(
-                    {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0},
+                    {
+                        "resume_path": "test.pdf",
+                        "job_urls": ["https://example.com"],
+                        "errors": [],
+                        "total_applied": 0,
+                        "total_skipped": 0,
+                        "current_job_index": 0,
+                    },
                     config=config,
                 )
 

--- a/tests/test_generate_cover_letter.py
+++ b/tests/test_generate_cover_letter.py
@@ -1,0 +1,141 @@
+"""Tests for the generate_cover_letter node."""
+
+from typing import Any
+from unittest.mock import patch
+
+from apply_operator.nodes.generate_cover_letter import generate_cover_letter
+from apply_operator.state import ApplicationState, JobListing, ResumeData
+
+
+def _make_state(
+    jobs: list[JobListing] | None = None,
+    current_job_index: int = 0,
+) -> ApplicationState:
+    resume = ResumeData(
+        raw_text="Jane Smith\nPython Developer",
+        name="Jane Smith",
+        skills=["Python", "Django", "PostgreSQL"],
+        experience=[
+            {
+                "title": "Backend Engineer",
+                "company": "Acme",
+                "duration": "2021-2024",
+                "description": "Built APIs",
+            }
+        ],
+        summary="Experienced backend developer with 3+ years in Python.",
+    )
+    if jobs is None:
+        jobs = [
+            JobListing(
+                url="https://example.com/jobs/1",
+                title="Python Developer",
+                company="TechCo",
+                description="Looking for a Python developer with Django experience.",
+                fit_score=0.8,
+            ),
+        ]
+    return {
+        "resume": resume,
+        "jobs": jobs,
+        "current_job_index": current_job_index,
+        "errors": [],
+        "resume_path": "",
+        "job_urls": [],
+        "total_applied": 0,
+        "total_skipped": 0,
+    }
+
+
+class TestGenerateCoverLetter:
+    """Tests for generate_cover_letter node function."""
+
+    @patch("apply_operator.nodes.generate_cover_letter.call_llm")
+    def test_generates_cover_letter(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '{"cover_letter": "Dear Hiring Manager, ..."}'
+        state = _make_state()
+
+        result = generate_cover_letter(state)
+
+        assert result["jobs"][0].cover_letter == "Dear Hiring Manager, ..."
+        assert "errors" not in result
+
+    @patch("apply_operator.nodes.generate_cover_letter.call_llm")
+    def test_handles_invalid_json(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = "not valid json"
+        state = _make_state()
+
+        result = generate_cover_letter(state)
+
+        assert result["jobs"][0].cover_letter == ""
+        assert len(result["errors"]) == 1
+        assert "Cover letter generation failed" in result["errors"][0]
+
+    @patch("apply_operator.nodes.generate_cover_letter.call_llm")
+    def test_handles_missing_cover_letter_key(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '{"something_else": "value"}'
+        state = _make_state()
+
+        result = generate_cover_letter(state)
+
+        assert result["jobs"][0].cover_letter == ""
+        assert "errors" not in result
+
+    @patch("apply_operator.nodes.generate_cover_letter.call_llm")
+    def test_handles_markdown_wrapped_json(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '```json\n{"cover_letter": "Dear TechCo team, ..."}\n```'
+        state = _make_state()
+
+        result = generate_cover_letter(state)
+
+        assert result["jobs"][0].cover_letter == "Dear TechCo team, ..."
+
+    def test_out_of_bounds_index_returns_empty(self) -> None:
+        state = _make_state(current_job_index=5)
+
+        result = generate_cover_letter(state)
+
+        assert result == {}
+
+    def test_empty_jobs_list_returns_empty(self) -> None:
+        state = _make_state(jobs=[], current_job_index=0)
+
+        result = generate_cover_letter(state)
+
+        assert result == {}
+
+    @patch("apply_operator.nodes.generate_cover_letter.call_llm")
+    def test_does_not_advance_index(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '{"cover_letter": "Dear ..."}'
+        state = _make_state()
+
+        result = generate_cover_letter(state)
+
+        assert "current_job_index" not in result
+
+    @patch("apply_operator.nodes.generate_cover_letter.call_llm")
+    def test_updates_correct_job_by_index(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '{"cover_letter": "For Job B"}'
+        jobs = [
+            JobListing(url="https://example.com/1", title="Job A", fit_score=0.8),
+            JobListing(url="https://example.com/2", title="Job B", fit_score=0.9),
+        ]
+        state = _make_state(jobs=jobs, current_job_index=1)
+
+        result = generate_cover_letter(state)
+
+        assert result["jobs"][0].cover_letter == ""  # unchanged
+        assert result["jobs"][1].cover_letter == "For Job B"
+
+    @patch("apply_operator.nodes.generate_cover_letter.call_llm")
+    def test_prompt_includes_resume_and_job_data(self, mock_call_llm: Any) -> None:
+        mock_call_llm.return_value = '{"cover_letter": "..."}'
+        state = _make_state()
+
+        generate_cover_letter(state)
+
+        prompt = mock_call_llm.call_args[0][0]
+        assert "Jane Smith" in prompt
+        assert "Python" in prompt
+        assert "TechCo" in prompt
+        assert "Python Developer" in prompt

--- a/tests/test_graph.py
+++ b/tests/test_graph.py
@@ -32,6 +32,7 @@ class TestGraphCompilation:
             "search_jobs",
             "analyze_fit",
             "skip_job",
+            "generate_cover_letter",
             "fill_application",
             "report_results",
         }
@@ -111,6 +112,11 @@ def _fake_fill(state: ApplicationState) -> dict[str, Any]:
     }
 
 
+def _noop_cover_letter(state: ApplicationState) -> dict[str, Any]:
+    """Mock generate_cover_letter: no-op (cover letter stays empty)."""
+    return {}
+
+
 def _noop_report(state: ApplicationState) -> dict[str, Any]:
     """Mock report_results: no-op."""
     return {}
@@ -130,6 +136,7 @@ class TestFullPipeline:
             patch("apply_operator.graph.parse_resume", _fake_parse),
             patch("apply_operator.graph.search_jobs", _fake_search(jobs)),
             patch("apply_operator.graph.analyze_fit", _fake_analyze(scores)),
+            patch("apply_operator.graph.generate_cover_letter", _noop_cover_letter),
             patch("apply_operator.graph.fill_application", _fake_fill),
         ]
         if mock_report:
@@ -152,7 +159,14 @@ class TestFullPipeline:
 
         graph = self._build_mocked_graph(jobs, scores)
         result = await graph.ainvoke(
-            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
+            {
+                "resume_path": "test.pdf",
+                "job_urls": ["https://example.com"],
+                "errors": [],
+                "total_applied": 0,
+                "total_skipped": 0,
+                "current_job_index": 0,
+            }
         )
 
         assert result["total_applied"] == 2
@@ -169,7 +183,14 @@ class TestFullPipeline:
         """Pipeline terminates cleanly when no jobs are found."""
         graph = self._build_mocked_graph(jobs=[], scores=[])
         result = await graph.ainvoke(
-            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
+            {
+                "resume_path": "test.pdf",
+                "job_urls": ["https://example.com"],
+                "errors": [],
+                "total_applied": 0,
+                "total_skipped": 0,
+                "current_job_index": 0,
+            }
         )
 
         assert result["total_applied"] == 0
@@ -183,7 +204,14 @@ class TestFullPipeline:
 
         graph = self._build_mocked_graph(jobs, scores)
         result = await graph.ainvoke(
-            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
+            {
+                "resume_path": "test.pdf",
+                "job_urls": ["https://example.com"],
+                "errors": [],
+                "total_applied": 0,
+                "total_skipped": 0,
+                "current_job_index": 0,
+            }
         )
 
         assert result["total_applied"] == 0
@@ -198,7 +226,14 @@ class TestFullPipeline:
 
         graph = self._build_mocked_graph(jobs, scores)
         result = await graph.ainvoke(
-            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
+            {
+                "resume_path": "test.pdf",
+                "job_urls": ["https://example.com"],
+                "errors": [],
+                "total_applied": 0,
+                "total_skipped": 0,
+                "current_job_index": 0,
+            }
         )
 
         assert result["total_applied"] == 2
@@ -213,7 +248,14 @@ class TestFullPipeline:
 
         graph = self._build_mocked_graph(jobs, scores)
         result = await graph.ainvoke(
-            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
+            {
+                "resume_path": "test.pdf",
+                "job_urls": ["https://example.com"],
+                "errors": [],
+                "total_applied": 0,
+                "total_skipped": 0,
+                "current_job_index": 0,
+            }
         )
 
         assert result["total_applied"] == 1
@@ -228,7 +270,14 @@ class TestFullPipeline:
 
         graph = self._build_mocked_graph(jobs, scores)
         result = await graph.ainvoke(
-            {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
+            {
+                "resume_path": "test.pdf",
+                "job_urls": ["https://example.com"],
+                "errors": [],
+                "total_applied": 0,
+                "total_skipped": 0,
+                "current_job_index": 0,
+            }
         )
 
         assert result["total_applied"] == 0
@@ -255,7 +304,14 @@ class TestFullPipeline:
             mock_path_obj.write_text.side_effect = lambda text: output_path.write_text(text)
 
             await graph.ainvoke(
-                {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
+                {
+                    "resume_path": "test.pdf",
+                    "job_urls": ["https://example.com"],
+                    "errors": [],
+                    "total_applied": 0,
+                    "total_skipped": 0,
+                    "current_job_index": 0,
+                }
             )
 
         assert output_path.exists()
@@ -270,7 +326,14 @@ class TestFullPipeline:
         scores = [0.7]
 
         graph = self._build_mocked_graph(jobs, scores)
-        initial = {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
+        initial = {
+            "resume_path": "test.pdf",
+            "job_urls": ["https://example.com"],
+            "errors": [],
+            "total_applied": 0,
+            "total_skipped": 0,
+            "current_job_index": 0,
+        }
 
         node_names: list[str] = []
         async for event in graph.astream(initial, stream_mode="updates"):
@@ -281,6 +344,7 @@ class TestFullPipeline:
         assert "parse_resume" in node_names
         assert "search_jobs" in node_names
         assert "analyze_fit" in node_names
+        assert "generate_cover_letter" in node_names
         assert "fill_application" in node_names
         assert "report_results" in node_names
 
@@ -294,7 +358,14 @@ class TestFullPipeline:
         graph1 = self._build_mocked_graph(jobs, scores)
         graph2 = self._build_mocked_graph(jobs, [0.8, 0.4])
 
-        initial = {"resume_path": "test.pdf", "job_urls": ["https://example.com"], "errors": [], "total_applied": 0, "total_skipped": 0, "current_job_index": 0}
+        initial = {
+            "resume_path": "test.pdf",
+            "job_urls": ["https://example.com"],
+            "errors": [],
+            "total_applied": 0,
+            "total_skipped": 0,
+            "current_job_index": 0,
+        }
 
         # Get result via ainvoke
         invoke_result = await graph1.ainvoke(initial)


### PR DESCRIPTION
## Summary

- Add `generate_cover_letter` node that creates tailored cover letters for high-fit jobs using LLM
- Node runs between `analyze_fit` and `fill_application` — only jobs with fit >= 0.6 get a cover letter
- `fill_application` uses the pre-generated cover letter when filling form fields

## Motivation

Resolves https://github.com/takeshi-su57/apply-operator/issues/27

Previously, cover letter content was generated inline during form filling via a generic instruction in the `MAP_FORM_FIELDS` prompt ("compose a brief 2-3 sentence answer"). A dedicated node generates a proper multi-paragraph cover letter once per job, tailored to the specific role and company.

## Changes

### New files
- **`src/apply_operator/nodes/generate_cover_letter.py`** — New node following the `analyze_fit` pattern: `@log_node`, dict state access, `call_llm()` with JSON response, stores cover letter on `JobListing.cover_letter` via `model_copy()`
- **`src/apply_operator/prompts/cover_letter.py`** — `GENERATE_COVER_LETTER` prompt template (resume + job details → 2-3 paragraph letter)
- **`tests/test_generate_cover_letter.py`** — 9 tests: generation, invalid JSON, missing key, markdown wrapping, out-of-bounds, empty jobs, index correctness, prompt content

### Modified files
- **`src/apply_operator/state.py`** — Added `cover_letter: str = ""` to `JobListing`
- **`src/apply_operator/graph.py`** — Inserted `generate_cover_letter` node: `analyze_fit → [fit >= 0.6] → generate_cover_letter → fill_application`
- **`src/apply_operator/nodes/__init__.py`** — Added export
- **`src/apply_operator/nodes/fill_application.py`** — `_map_fields_with_llm` passes `job.cover_letter` to the prompt
- **`src/apply_operator/prompts/form_filling.py`** — Updated `MAP_FORM_FIELDS` to use pre-generated cover letter when available
- **`tests/test_graph.py`** — Added `generate_cover_letter` mock and expected node name
- **`tests/test_checkpoint.py`** — Added mock to all patched graph builders

## How to Test

```bash
uv pip install -e ".[dev]"
pytest tests/ -v                    # 202 tests pass (9 new)
ruff check src/ tests/              # All checks passed
mypy src/                           # No issues

# Manual: run pipeline and observe cover letter generation in logs
python -m apply_operator run --resume resume.pdf --urls urls.txt -v
# High-fit jobs will show "Cover letter for <title> (<company>): <N> chars"
```

Checklist
 Sel

- [x] f-reviewed the code
- [x]  Added/updated tests (9 new tests)
- [x]  No new warnings or errors
- [x]  ruff check, mypy, and pytest all pass (202 tests)
- [x]  Updated d

ocumentation (issue doc)